### PR TITLE
Update 2.0 http api reference

### DIFF
--- a/docs/reference/http/examples.md
+++ b/docs/reference/http/examples.md
@@ -558,6 +558,35 @@ Action: GET
 Endpoint: http://localhost:8090/fdb/health
 ```
 
+## /garbage-collect-ledger {#garbage-collect-ledger}
+
+A POST request to `/fdb/garbage-collect-ledger` with valid ledger ID contained in the payload will initiate the garbage collection process for the specified ledger, if needed.
+
+```http
+Action: POST
+Endpoint: http://localhost:8090/fdb/garbage-collect-ledger
+Body: {
+  "ledger/id": "test/dev"
+}
+```
+
+There will be no response until the ledger has completed the operation.
+Once garbage collection is completed, the response will resemble the example below.
+
+```json
+{
+  "garbage-collected": "test/dev"
+}
+```
+
+If there was no "garbage" to collect, the response will look like this.
+
+```json
+{
+  "no-garbage": "test/dev"
+}
+```
+
 ## /ledger-stats {#ledger-stats}
 
 A POST request to `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` provides stats about the requested ledger.

--- a/docs/reference/http/examples.md
+++ b/docs/reference/http/examples.md
@@ -561,6 +561,8 @@ Endpoint: http://localhost:8090/fdb/health
 ## /garbage-collect-ledger {#garbage-collect-ledger}
 
 A POST request to `/fdb/garbage-collect-ledger` with valid ledger ID contained in the payload will initiate the garbage collection process for the specified ledger, if needed.
+This process is useful for freeing up disk space for ledgers which have had a large number of transactions.
+Any "stale" index nodes that are no longer needed by the ledger will be removed from storage.
 
 ```http
 Action: POST

--- a/docs/reference/http/examples.md
+++ b/docs/reference/http/examples.md
@@ -1,9 +1,11 @@
 ---
 sidebar_position: 2
 ---
+
 # HTTP Examples
 
-In order to ensure speed of processing queries and transactions, different types of queries and transactions should be issued to different endpoints. All requests, unless otherwise specified, should be POST requests.
+In order to ensure speed of processing queries and transactions, different types of queries and transactions should be issued to different endpoints.
+All requests, unless otherwise specified, should be POST requests.
 
 ## /ledgers {#ledgers}
 
@@ -25,7 +27,8 @@ A ledger id must begin with a network name followed by a `/` and a ledger name.
 Network and ledger names may only contain lowercase letters and numbers.
 In your request, you must specify a `ledger/id` key.
 
-If the network specified does not exist, it creates a new network. This request returns a command id, the request does not wait to ledger to be fully initialized before returning.
+If the network specified does not exist, it creates a new network.
+This request returns a command id, the request does not wait to ledger to be fully initialized before returning.
 
 These requests do not need to be signed.
 
@@ -38,7 +41,8 @@ Body: {"ledger/id": "test/one"}
 
 ## /nw-state {#nw-state}
 
-This provides a status of the Fluree network as recorded by a particular (ledger or transact) server.  Status information includes raft state, list of servers in the Fluree network, list of ledgers, and the current # of transactions queued.
+This provides a status of the Fluree network as recorded by a particular (ledger or transact) server.
+Status information includes raft state, list of servers in the Fluree network, list of ledgers, and the current # of transactions queued.
 
 To retrieve the status, simply send an empty POST request to the `/nw-state` endpoint.
 
@@ -51,40 +55,40 @@ Body: None
 
 The result is a map of key/value pairs, for example:
 
-```http
-{:snapshot-term 11,
- :latest-index 19940,
- :snapshot-index 19800,
- :other-servers [],
- :index 19940,
- :snapshot-pending nil,
- :term 11,
- :leader "myserver",
- :timeout-at 1611088055092,
- :this-server "myserver",
- :status "leader",
- :id 88389,
- :svr-state [{:id "myserver", :active? true}],
- :commit 19940,
- :servers {:myserver {:vote [11 true],
-                      :next-index 19748,
-                      :match-index 19940,
-                      :snapshot-index nil,
-                      :stats {:sent 0, :received 0, :avg-response 0}}},
- :raft {:version 3,
-        :leases {:servers {:myserver {:id "myserver", :expire 1611088056918}}},
-        :_work {:networks {:test "myserver"}},
-        :_worker {:myserver {:networks {:test 1610570486137}}},
-        :cmd-queue [{:test 0}],
-        :new-db-queue [{:test 0}],
-        :networks {:test {:dbs {:chat {:status "ready", :block 6, :index 1, :indexes {:1 1610570484628}},
-                                :invoice {:status "ready", :block 5, :index 1, :indexes {:1 1610571471362}},
-                                :test/nl-1 {},
-                                :nl-2 {:status "ready", :block 2, :index 1, :indexes {:1 1610985470087}},
-                                :test/nl-2 {}}}}},
- :voted-for "myserver",
- :open-api true,
- :timeout-ms 666}
+```json
+{"snapshot-term": 11,
+ "latest-index": 19940,
+ "snapshot-index": 19800,
+ "other-servers": [],
+ "index": 19940,
+ "snapshot-pending": null,
+ "term": 11,
+ "leader": "myserver",
+ "timeout-at": 1611088055092,
+ "this-server": "myserver",
+ "status": "leader",
+ "id": 88389,
+ "svr-state": [{"id": "myserver", "active?": true}],
+ "commit": 19940,
+ "servers": {"myserver": {"vote": [11 true],
+                      "next-index": 19748,
+                      "match-index": 19940,
+                      "snapshot-index": null,
+                      "stats": {"sent": 0, "received": 0, "avg-response": 0}}},
+ "raft": {"version": 3,
+        "leases": {"servers": {"myserver": {"id": "myserver", "expire": 1611088056918}}},
+        "_work": {"networks": {"test": "myserver"}},
+        "_worker": {"myserver": {"networks": {"test": 1610570486137}}},
+        "cmd-queue": [{"test": 0}],
+        "new-ledger-queue": [{"test": 0}],
+        "networks": {"test": {"ledgers": {"chat": {"status": "ready", "block": 6, "index": 1, "indexes": {"1": 1610570484628}},
+                                "invoice": {"status": "ready", "block": 5, "index": 1, "indexes": {"1": 1610571471362}},
+                                "test/nl-1": {},
+                                "nl-2": {"status": "ready", "block": 2, "index": 1, "indexes": {"1": 1610985470087}},
+                                "test/nl-2": {}}}}},
+ "voted-for": "myserver",
+ "open-api": true,
+ "timeout-ms": 666}
 ```
 
 ## /export {#export}
@@ -110,7 +114,10 @@ Body: { "format": "xml" , "block": 10 }
 
 ## /delete-ledger {#delete-ledger}
 
-This deletes a ledger. Deleting a ledger means that a user will no longer be able to query or transact against that ledger, but currently the actual ledger files will not be deleted on disk. You can choose to delete those files yourself - or keep them. You will not be able to create a new ledger with the same name as the deleted ledger.
+This deletes a ledger.
+Deleting a ledger means that a user will no longer be able to query or transact against that ledger, but currently the actual ledger files will not be deleted on disk.
+You can choose to delete those files yourself - or keep them.
+You will not be able to create a new ledger with the same name as the deleted ledger.
 
 Use the following request when Fluree server is running in open-api mode (i.e., fdb-api-open=true)
 
@@ -191,35 +198,37 @@ Body: { "query1": { "select": ["*"], "from": "_collection"},
         "query2": { "select": ["*"], "from": "_predicate"}}
 ```
 
-To build the body of this query, create unique names for your queries, and set those as the keys of the your JSON query. The values of the keys should be the queries themselves.
+To build the body of this query, create unique names for your queries, and set those as the keys of the your JSON query.
+The values of the keys should be the queries themselves.
 
 For example, this query selects all chats and people at once.
 
 ```json
 {
-    "chatQuery": {
-        "select": ["*"],
-        "from": "chat"
-    },
-    "personQuery": {
-         "select": ["*"],
-        "from": "person"
-    }
+  "chatQuery": {
+    "select": ["*"],
+    "from": "chat"
+  },
+  "personQuery": {
+    "select": ["*"],
+    "from": "person"
+  }
 }
 ```
 
-Any errors will be returned in a header, called `X-Fdb-Errors`. For example, incorrectCollection is attempting to query a collection that does not exist.
+Any errors will be returned in a header, called `X-Fdb-Errors`.
+For example, incorrectCollection is attempting to query a collection that does not exist.
 
 ```json
 {
-    "incorrectCollection": {
-        "select": ["*"],
-        "from": "apples"
-    },
-    "personQuery": {
-         "select": ["*"],
-        "from": "person"
-    }
+  "incorrectCollection": {
+    "select": ["*"],
+    "from": "apples"
+  },
+  "personQuery": {
+    "select": ["*"],
+    "from": "person"
+  }
 }
 ```
 
@@ -241,7 +250,8 @@ The response will have a status of 207, and it will only return the response for
 
 ## /block {#block}
 
-FlureeQL [block queries](/overview/query/block_query.mdx) should be submitted to the `/block` endpoint. This does not include other types of queries (basic queries, history queries, etc) that might have a "block" key. This only includes queries like those in the linked section - queries that are returning flakes from a block or set of blocks.
+FlureeQL [block queries](/overview/query/block_query.mdx) should be submitted to the `/block` endpoint. This does not include other types of queries (basic queries, history queries, etc) that might have a "block" key.
+This only includes queries like those in the linked section - queries that are returning flakes from a block or set of blocks.
 
 An example of an unsigned request to `/block`:
 
@@ -254,7 +264,8 @@ Body: { "block": 5 }
 
 ## /history {#history}
 
-FlureeQL [history queries](/overview/query/history_query.mdx) should be submitted to the `/history` endpoint. This only includes queries like those in the linked section.
+FlureeQL [history queries](/overview/query/history_query.mdx) should be submitted to the `/history` endpoint.
+This only includes queries like those in the linked section.
 
 An example of an unsigned request to `/history`:
 
@@ -272,7 +283,8 @@ Body: {
 
 All unsigned transactions, except transaction issued through the GraphQL syntax, should be issued to the `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/transact` endpoint.
 
-If you do not have `fdb-api-open` set to true (it is true by default), then you cannot use the `/transact` endpoint. You'll need to use the [`/command` endpoint](#command).
+If you do not have `fdb-api-open` set to true (it is true by default), then you cannot use the `/transact` endpoint.
+You'll need to use the [`/command` endpoint](#command).
 
 An example of an unsigned request to `/transact`:
 
@@ -286,9 +298,13 @@ Body: [{
   }]
 ```
 
-By specifying a `Request-Timeout` header, you can set a transaction timeout. The maximum transaction size that is currently permitted by Fluree is 2MB. A sufficiently large transaction can take 50 seconds or longer to be resolved. By default, your request will timeout after 60 seconds.
+By specifying a `Request-Timeout` header, you can set a transaction timeout.
+The maximum transaction size that is currently permitted by Fluree is 2MB.
+A sufficiently large transaction can take 50 seconds or longer to be resolved.
+By default, your request will timeout after 60 seconds.
 
-An example of setting your own custom timeout is below. The value provided to `Request-Timeout` is in milliseconds.
+An example of setting your own custom timeout is below.
+The value provided to `Request-Timeout` is in milliseconds.
 
 ```http
 Action: POST
@@ -390,7 +406,8 @@ To see examples of sending a request to the `/command` endpoint, see [signed tra
 
 ## /reindex {#reindex}
 
-Available in `0.11.7` or higher. Reindexes the specified ledger.
+Available in `0.11.7` or higher.
+Reindexes the specified ledger.
 
 ```http
 Action: POST
@@ -399,17 +416,18 @@ Headers: None
 Body: None
 ```
 
-This request may take some time to return. It will return a map, such as the following:
+This request may take some time to return.
+It will return a map, such as the following:
 
 ```json
 {
-    "block": 13,
-    "t": -27,
-    "stats": {
-        "flakes": 899990,
-        "size": 41435614,
-        "indexed": 13
-    }
+  "block": 13,
+  "t": -27,
+  "stats": {
+    "flakes": 899990,
+    "size": 41435614,
+    "indexed": 13
+  }
 }
 ```
 
@@ -422,24 +440,25 @@ Headers: None
 Body: None
 ```
 
-This request may take some time to return. It will return a map, such as the following:
+This request may take some time to return.
+It will return a map, such as the following:
 
 ```json
 {
-    "block": 13,
-    "t": -27,
-    "stats": {
-        "flakes": 899990,
-        "size": 41435614,
-        "indexed": 13
-    }
+  "block": 13,
+  "t": -27,
+  "stats": {
+    "flakes": 899990,
+    "size": 41435614,
+    "indexed": 13
+  }
 }
 ```
 
 ## /hide {#hide}
 
-This is a beta feature. To read about how it works, visit
-[hiding flakes](/concepts/infrastructure/mutability.md#hiding-flakes).
+This is a beta feature.
+To read about how it works, visit [hiding flakes](/concepts/infrastructure/mutability.md#hiding-flakes).
 
 ```http
 Action: POST
@@ -453,7 +472,10 @@ Body: {
 
 ## /gen-flakes {#gen-flakes}
 
-Returns the list of flakes that would be added to a ledger if a given transaction is issued. The body of this request is simply the transaction. Note that this is a test endpoint. This does _NOT_ write the returned flakes to the ledger.
+Returns the list of flakes that would be added to a ledger if a given transaction is issued.
+The body of this request is simply the transaction.
+Note that this is a test endpoint.
+This does _NOT_ write the returned flakes to the ledger.
 
 ```http
 Action: POST
@@ -471,12 +493,13 @@ Returns the results of a query using the existing ledger flakes, including flake
 
 The request expects a map with two key-value pairs:
 
-| Key      | Value                                                                              |
-| -------- | ---------------------------------------------------------------------------------- |
-| `flakes` | An array of valid flakes                                                           |
+| Key      | Value                                                                            |
+| -------- | -------------------------------------------------------------------------------- |
+| `flakes` | An array of valid flakes                                                         |
 | `query`  | A query to issue against the current ledger plus the flakes in the flakes value. |
 
-The `t` on the flakes provided has to be current with the latest ledger. For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
+The `t` on the flakes provided has to be current with the latest ledger.
+For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
 
 ```http
 Action: POST
@@ -493,13 +516,14 @@ Given a valid set of flakes that could be added to the ledger at a given point i
 
 The request expects a map with the following key-value pairs:
 
-| Key      | Value                                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flakes` | An array of valid flakes                                                                                                                                        |
+| Key      | Value                                                                                                                                                         |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flakes` | An array of valid flakes                                                                                                                                      |
 | `txn`    | A transaction to issue against the current ledger plus the flakes in the flakes value. This endpoint does _NOT_ actually write the transaction to the ledger. |
-| `auth`   | (Optional) The `_auth/id` with which to issue the transaction.                                                                                                  |
+| `auth`   | (Optional) The `_auth/id` with which to issue the transaction.                                                                                                |
 
-The `t` on the flakes provided has to be current with the latest ledger. For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
+The `t` on the flakes provided has to be current with the latest ledger.
+For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
 
 ```http
 Action: POST
@@ -525,7 +549,9 @@ Body: {
 
 ## /health {#health}
 
-A GET request to `/fdb/health` returns whether the server is ready or not. You are not able to test this endpoint in the sidebar. These requests do not need to be signed.
+A GET request to `/fdb/health` returns whether the server is ready or not.
+You are not able to test this endpoint in the sidebar.
+These requests do not need to be signed.
 
 ```http
 Action: GET
@@ -563,17 +589,23 @@ Endpoint: http://localhost:8090/fdb/storage/[NETWORK-NAME]/[LEDGER-NAME]/[TYPE]/
 
 ## /sub {#sub}
 
-A POST request to `/fdb/sub` handles subscriptions. More documentation on this feature coming soon. You are not able to test this endpoint in the sidebar. These requests do not need to be signed.
+A POST request to `/fdb/sub` handles subscriptions.
+More documentation on this feature coming soon.
+You are not able to test this endpoint in the sidebar.
+These requests do not need to be signed.
 
 ## /new-keys {#new-keys}
 
-A POST request with an empty object or a GET request to `/fdb/new-keys` returns a valid public key, private key, and auth-id. Learn more about [how identity is established in Fluree](/concepts/identity/auth_records.md#generating-a-public-private-key-auth-id-triple). These requests do not need to be signed.
+A POST request with an empty object or a GET request to `/fdb/new-keys` returns a valid public key, private key, and auth-id.
+Learn more about [how identity is established in Fluree](/concepts/identity/auth_records.md#generating-a-public-private-key-auth-id-triple).
+These requests do not need to be signed.
 
 ## /pw/generate {#pwgenerate}
 
 See the [Password Management Guide](/concepts/identity/password_management.md) for more information.
 
-Returns a valid token for a given user or role. Sets a valid password for that user or role.
+Returns a valid token for a given user or role.
+Sets a valid password for that user or role.
 
 | Keys     | Required | Explanations                                                                                                                                                                                                                               |
 | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -601,7 +633,8 @@ Body: {
 
 See the [Password Management Guide](/concepts/identity/password_management.md) for more information.
 
-This endpoint returns a valid JWT token. You need to pass a NON-expired JWT token in the header, and an expiration time (in epoch milliseconds from now), to the body of the request.
+This endpoint returns a valid JWT token.
+You need to pass a NON-expired JWT token in the header, and an expiration time (in epoch milliseconds from now), to the body of the request.
 
 | Keys   | Required | Explanations                                       |
 | ------ | -------- | -------------------------------------------------- |

--- a/docs/reference/http/examples.md
+++ b/docs/reference/http/examples.md
@@ -561,7 +561,7 @@ Endpoint: http://localhost:8090/fdb/health
 ## /garbage-collect-ledger {#garbage-collect-ledger}
 
 A POST request to `/fdb/garbage-collect-ledger` with valid ledger ID contained in the payload will initiate the garbage collection process for the specified ledger, if needed.
-This process is useful for freeing up disk space for ledgers which have had a large number of transactions.
+This process is useful for freeing up disk space for ledgers which have had a large number of transactions or re-indexing operations.
 Any "stale" index nodes that are no longer needed by the ledger will be removed from storage.
 
 ```http

--- a/docs/reference/http/overview.md
+++ b/docs/reference/http/overview.md
@@ -2,64 +2,62 @@
 sidebar_position: 1
 sidebar_label: Overview
 ---
+
 # Overview
 
 Downloaded endpoints can only be used in the downloadable versions of Fluree. All requests, except requests to `/health`, should be POST requests. The main downloaded endpoints are below, and they are all structured as follows:
 
-`/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/[ACTION]`
+`/fdb/[NETWORK-NAME]/[LEDGER-NAME]/[ACTION]`
 
-- For the downloadable version, unless you changed the default `fdb-api-port`, the full URL is `http://localhost:8090/fdb/[DBNAME]/[ACTION]`
+- For the downloadable version, unless you changed the default `fdb-api-port`, the full URL is `http://localhost:8090/fdb/[NETWORK-NAME]/[LEDGER-NAME]/[ACTION]`
 
 ## Main Endpoints {#main-endpoints}
 
-Action | Endpoint | Explanation
--- | -- | --
-DBs | `/fdb/dbs` | Returns a list of all ledgers in the transactor group.
-New DB | `/fdb/new-db` | Creates a new ledger
-Export | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/export` | Locally exports an existing ledger into either `.xml` or `.ttl`
-Delete DB | `/fdb/delete-db` | Deletes ledger (does not currently delete ledger files)
-Add Server | `/fdb/add-server` | (Beta feature) Dynamically adds a server to the network.
-Remove Server | `/fdb/remove-server`| (Beta feature) Dynamically removes a server from the network.
-Query | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/query` | Queries in FlureeQL syntax
-Multi-Query | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/multi-query` | Multi-Queries in FlureeQL syntax
-Block | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/block` | Block queries in FlureeQL syntax
-History |  `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/history`| History queries in FlureeQL syntax
-Transact | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/transact` | Transactions in FlureeQL syntax
-GraphQL | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/graphql` | Queries or transactions in GraphQL syntax, as a string
-SPARQL | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/sparql` | Queries in SPARQL syntax, as a string
-SQL | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/sql` | Queries in SQL syntax, as a string
-Command | `/fdb/[NETWORK-NAME]/[DBID]/command` | Commands, such as transactions, with a signature in the body. See [signing transactions](/concepts/identity/signatures.md#signed-transactions).
-Reindex | `/fdb/[NETWORK-NAME]/[DBID]/reindex` | Reindexes the specified ledger.
-Reindex-fullText | `/fdb/[NETWORK-NAME]/[DBID]/reindex-fulltext` | Reindexes the fullText index on the specified ledger.
-Hide | `/fdb/[NETWORK-NAME]/[DBID]/hide` | Hides flakes that match the given pattern.
+| Action           | Endpoint                                             | Explanation                                                                                                                                     |
+| ---------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ledgers          | `/fdb/ledgers`                                       | Returns a list of all ledgers in the transactor group.                                                                                          |
+| New Ledger       | `/fdb/new-ledger`                                    | Creates a new ledger                                                                                                                            |
+| Delete Ledger    | `/fdb/delete-ledger`                                 | Deletes ledger (does not currently delete ledger files)                                                                                         |
+| Query            | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/query`            | Queries in FlureeQL syntax                                                                                                                      |
+| Multi-Query      | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/multi-query`      | Multi-Queries in FlureeQL syntax                                                                                                                |
+| Block            | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/block`            | Block queries in FlureeQL syntax                                                                                                                |
+| History          | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/history`          | History queries in FlureeQL syntax                                                                                                              |
+| Transact         | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/transact`         | Transactions in FlureeQL syntax                                                                                                                 |
+| GraphQL          | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/graphql`          | Queries or transactions in GraphQL syntax, as a string                                                                                          |
+| SPARQL           | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/sparql`           | Queries in SPARQL syntax, as a string                                                                                                           |
+| SQL              | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/sql`              | Queries in SQL syntax, as a string                                                                                                              |
+| Command          | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/command`          | Commands, such as transactions, with a signature in the body. See [signing transactions](/concepts/identity/signatures.md#signed-transactions). |
+| Reindex          | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/reindex`          | Reindexes the specified ledger.                                                                                                                 |
+| Reindex-fullText | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/reindex-fulltext` | Reindexes the fullText index on the specified ledger.                                                                                           |
+| Hide             | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/hide`             | Hides flakes that match the given pattern.                                                                                                      |
 
 ## Test endpoints {#test-endpoints}
 
-Action | Endpoint | Explanation
--- | -- | --
-Generate Flakes | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/gen-flakes` | Returns the list of flakes that would be added to a ledger if a given transaction is issued.
-Query With | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/query-with` | Returns the results of a query using the existing ledger flakes, including flakes that are provided with the query.
-Test Transact With | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/test-transact-with` | Given a valid set of flakes that could be added to the ledger at a given point in time and a transaction, returns the flakes that would be added to a ledger if a given transaction is issued.
+| Action             | Endpoint                                               | Explanation                                                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Generate Flakes    | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/gen-flakes`         | Returns the list of flakes that would be added to a ledger if a given transaction is issued.                                                                                                   |
+| Query With         | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/query-with`         | Returns the results of a query using the existing ledger flakes, including flakes that are provided with the query.                                                                            |
+| Test Transact With | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/test-transact-with` | Given a valid set of flakes that could be added to the ledger at a given point in time and a transaction, returns the flakes that would be added to a ledger if a given transaction is issued. |
 
 ## Password Authentication Endpoints {#password-authentication-endpoints}
 
 You need password authentication enabled to use these endpoints. See [config options](/reference/fluree_config.md#password-and-jwt-token-settings) for all password authentication options. See the [Password Management Guide](/concepts/identity/password_management.md) for more information. For an implementation example refer to the [Comics Store](https://github.com/fluree/developer-hub) repo located in the Fluree Developer Hub.
 
-Action | Endpoint | Explanation
--- | -- | --
-[Generate](/reference/http/examples.md#pwgenerate) | `/fdb/[NETWORK-NAME]/[DBID]/pw/generate` | Returns a valid token for a given user or role. Sets a valid password for that user or role.
-[Renew](/reference/http/examples.md#pwrenew) | `/fdb/[NETWORK-NAME]/[DBID]/pw/renew` | Given a token in the header and a new expiration time, returns a new token for a given user or role.
-[Login](/reference/http/examples.md#pwlogin) | `/fdb/[NETWORK-NAME]/[DBID]/pw/login` | Given a password and user or auth id, returns a valid token.
+| Action                                             | Endpoint                                        | Explanation                                                                                          |
+| -------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Generate](/reference/http/examples.md#pwgenerate) | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/pw/generate` | Returns a valid token for a given user or role. Sets a valid password for that user or role.         |
+| [Renew](/reference/http/examples.md#pwrenew)       | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/pw/renew`    | Given a token in the header and a new expiration time, returns a new token for a given user or role. |
+| [Login](/reference/http/examples.md#pwlogin)       | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/pw/login`    | Given a password and user or auth id, returns a valid token.                                         |
 
 ## Other endpoints {#other-endpoints}
 
-Action | Verb | Endpoint | Description
--- | -- | -- | --
-Block Stats | POST | `/fdb/[NETWORK-NAME]/[DBID]/block-range-with-txn` | Block data, including signatures, instant, hash, flakes and transactions
-Health | ANY | `/fdb/health` | Returns whether or not the server is ready.
-Ledger Stats | POST | `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` | General ledger stats, including status, # flakes, current block, and size (kb).
-Sub | POST | `/fdb/sub` | Handles subscriptions
-Network Status | ANY | `/fdb/nw-state` | Returns status of Fluree network, raft state, etc.
+| Action         | Method | Endpoint                                                 | Description                                                                     |
+| -------------- | ------ | -------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Block Stats    | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/block-range-with-txn` | Block data, including signatures, instant, hash, flakes and transactions        |
+| Health         | ANY    | `/fdb/health`                                            | Returns whether or not the server is ready.                                     |
+| Ledger Stats   | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/ledger-stats`         | General ledger stats, including status, # flakes, current block, and size (kb). |
+| WebSocket      | GET    | `/fdb/ws`                                                | Handles websocket subscriptions                                                 |
+| Network Status | ANY    | `/fdb/nw-state`                                          | Returns status of Fluree network, raft state, etc.                              |
 
 For both queries and transactions, a signature is not required if the option `fdb-api-open` is set to true (default for the downloaded version of Fluree).
 

--- a/docs/reference/http/overview.md
+++ b/docs/reference/http/overview.md
@@ -56,13 +56,14 @@ For an implementation example refer to the [Comics Store](https://github.com/flu
 
 ## Other endpoints {#other-endpoints}
 
-| Action         | Method | Endpoint                                                 | Description                                                                     |
-| -------------- | ------ | -------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Block Stats    | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/block-range-with-txn` | Block data, including signatures, instant, hash, flakes and transactions        |
-| Health         | ANY    | `/fdb/health`                                            | Returns whether or not the server is ready.                                     |
-| Ledger Stats   | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/ledger-stats`         | General ledger stats, including status, # flakes, current block, and size (kb). |
-| WebSocket      | GET    | `/fdb/ws`                                                | Handles websocket subscriptions                                                 |
-| Network Status | ANY    | `/fdb/nw-state`                                          | Returns status of Fluree network, raft state, etc.                              |
+| Action             | Method | Endpoint                                                 | Description                                                                     |
+| ------------------ | ------ | -------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Block Stats        | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/block-range-with-txn` | Block data, including signatures, instant, hash, flakes and transactions        |
+| Health             | ANY    | `/fdb/health`                                            | Returns whether or not the server is ready.                                     |
+| Ledger Stats       | POST   | `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/ledger-stats`         | General ledger stats, including status, # flakes, current block, and size (kb). |
+| WebSocket          | GET    | `/fdb/ws`                                                | Handles websocket subscriptions                                                 |
+| Network Status     | ANY    | `/fdb/nw-state`                                          | Returns status of Fluree network, raft state, etc.                              |
+| Garbage Collection | POST   | `/fdb/garbage-collect-ledger`                            | Initialize garbage collection for a ledger                                      |
 
 For both queries and transactions, a signature is not required if the option `fdb-api-open` is set to true (default for the downloaded version of Fluree).
 

--- a/docs/reference/http/overview.md
+++ b/docs/reference/http/overview.md
@@ -5,7 +5,9 @@ sidebar_label: Overview
 
 # Overview
 
-Downloaded endpoints can only be used in the downloadable versions of Fluree. All requests, except requests to `/health`, should be POST requests. The main downloaded endpoints are below, and they are all structured as follows:
+Downloaded endpoints can only be used in the downloadable versions of Fluree.
+All requests, except requests to `/health`, should be POST requests.
+The main downloaded endpoints are below, and they are all structured as follows:
 
 `/fdb/[NETWORK-NAME]/[LEDGER-NAME]/[ACTION]`
 
@@ -41,7 +43,10 @@ Downloaded endpoints can only be used in the downloadable versions of Fluree. Al
 
 ## Password Authentication Endpoints {#password-authentication-endpoints}
 
-You need password authentication enabled to use these endpoints. See [config options](/reference/fluree_config.md#password-and-jwt-token-settings) for all password authentication options. See the [Password Management Guide](/concepts/identity/password_management.md) for more information. For an implementation example refer to the [Comics Store](https://github.com/fluree/developer-hub) repo located in the Fluree Developer Hub.
+You need password authentication enabled to use these endpoints.
+See [config options](/reference/fluree_config.md#password-and-jwt-token-settings) for all password authentication options.
+See the [Password Management Guide](/concepts/identity/password_management.md) for more information.
+For an implementation example refer to the [Comics Store](https://github.com/fluree/developer-hub) repo located in the Fluree Developer Hub.
 
 | Action                                             | Endpoint                                        | Explanation                                                                                          |
 | -------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This PR will update the HTTP API reference documentation to reflect the changes made with the 2.0 release. These changes include:
* no longer using the term "DB" in reference to ledgers
* adding the garbage-collection endpoint

If I am missing any major changes that still need to be documented / updated, please let me know, or make the appropriate changes and push them to this branch.