### PR TITLE
add note about creating ledger with owners option

### DIFF
--- a/docs/reference/http/examples.md
+++ b/docs/reference/http/examples.md
@@ -23,9 +23,10 @@ Body: Null
 
 ## /new-ledger {#new-ledger}
 
-A ledger id must begin with a network name followed by a `/` and a ledger name.
-Network and ledger names may only contain lowercase letters and numbers.
-In your request, you must specify a `ledger/id` key.
+A ledger id must begin with a network name followed by a `/` and a ledger name.  Network
+and ledger names may only contain lowercase letters and numbers.  In your request, you
+must specify a `ledger/id` key. You may optionally include an `owners` key with a value
+of an array of auth ids that you would like bootstrap as root in the new ledger.
 
 If the network specified does not exist, it creates a new network.
 This request returns a command id, the request does not wait to ledger to be fully initialized before returning.

--- a/docs/reference/javascript/examples.md
+++ b/docs/reference/javascript/examples.md
@@ -193,7 +193,7 @@ Creates a new ledger given a "network/id". If the network specified does not exi
 | Key          | Value                                                                                       |
 | ------------ | ------------------------------------------------------------------------------------------- |
 | `:alias`     | an alias for the ledger, if different than the id                                           |
-| `:root`      | account id to bootstrap with (string). Defaults to connection default account id            |
+| `:owners`    | auth ids to bootstrap with (array of string).                                               |
 | `:doc`       | doc string about this ledger                                                                |
 | `:fork`      | If forking an existing db, ref to db (actual identity, not db-ident). Must exist in network |
 | `:forkBlock` | If fork is provided, optionally provide the block to fork at. Defaults to latest known.     |


### PR DESCRIPTION
This adds a note about how to bootstrap a new ledger with the supplied `owners` auth ids as root auth ids.