### PR TITLE
docs: restructure querying reference

### DIFF
--- a/docs/reference/querying/advanced-features.mdx
+++ b/docs/reference/querying/advanced-features.mdx
@@ -1,0 +1,537 @@
+import Admonition from "@theme/Admonition";
+
+# Advanced Query Features
+
+Advanced query patterns for complex data retrieval scenarios.
+
+## Property Paths (Transitive Queries)
+
+Property paths allow you to traverse relationships across multiple hops in a single query. This is useful for querying hierarchical data like organizational structures, social networks, or category trees.
+
+### Syntax
+
+| Pattern | Description | Example |
+| ------- | ----------- | ------- |
+| `<prop+>` | One or more hops (transitive closure) | `"<ex:knows+>"` |
+| `<prop*>` | Zero or more hops (includes self) | `"<ex:knows*>"` |
+
+The property is wrapped in angle brackets with `+` or `*` suffix.
+
+### One or More Hops (`+`)
+
+Find everyone Alice knows directly or indirectly:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "select": "?who",
+  "where": {"@id": "ex:alice", "<ex:knows+>": "?who"}
+}
+```
+
+If Alice knows Bob, and Bob knows Carol, this returns both Bob and Carol.
+
+### Zero or More Hops (`*`)
+
+The `*` operator includes the starting node itself (reflexive transitive closure):
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "select": "?who",
+  "where": {"@id": "ex:alice", "<ex:knows*>": "?who"}
+}
+```
+
+This returns Alice, Bob, and Carol (Alice is included because of zero hops).
+
+### Finding Ancestors
+
+Property paths work in both directions. Find all ancestors of a person:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "select": "?ancestor",
+  "where": {"@id": "?ancestor", "<ex:parent+>": {"@id": "ex:alice"}}
+}
+```
+
+### All Pairs
+
+You can use variables on both sides to find all connected pairs:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "select": ["?person", "?connection"],
+  "where": {"@id": "?person", "<ex:knows+>": "?connection"}
+}
+```
+
+### Cycle Handling
+
+Property paths handle cycles automatically. If Alice knows Bob and Bob knows Alice, the query will still terminate and return the correct results without infinite loops.
+
+## Subqueries
+
+Subqueries allow you to nest one query inside another. They are useful for:
+- Computing aggregates and using them in the parent query
+- Limiting results before joining with other data
+- Combining results from multiple independent queries
+
+### Syntax
+
+```json
+["query", { ...query object... }]
+```
+
+Subqueries are placed in the `where` clause as an array with `"query"` as the first element.
+
+### Basic Subquery
+
+Join data from a subquery with the parent query:
+
+```json
+{
+  "@context": {"schema": "http://schema.org/"},
+  "select": ["?name", "?age"],
+  "where": [
+    {"@id": "?s", "schema:name": "?name"},
+    ["query", {
+      "select": ["?s", "?age"],
+      "where": {"@id": "?s", "schema:age": "?age"}
+    }]
+  ],
+  "orderBy": "?name"
+}
+```
+
+Variables bound in the subquery (`?s`, `?age`) are available in the parent query.
+
+### Subquery with Aggregate
+
+Calculate an aggregate in a subquery and use it in the parent:
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "select": ["?person", "?favNums"],
+  "where": [
+    {"@id": "?person", "ex:favNums": "?favNums"},
+    ["filter", "(> ?favNums ?avgFavNum)"],
+    ["query", {
+      "where": {"ex:favNums": "?favN"},
+      "select": ["(as (avg ?favN) ?avgFavNum)"]
+    }]
+  ]
+}
+```
+
+This finds people whose favorite numbers are above the overall average.
+
+### Subquery with Limit
+
+Limit results in a subquery before joining:
+
+```json
+{
+  "@context": {"schema": "http://schema.org/", "ex": "http://example.org/"},
+  "select": ["?age", "?favNums"],
+  "where": [
+    {"schema:age": "?age"},
+    ["query", {
+      "select": ["?favNums"],
+      "where": {"ex:favNums": "?favNums"},
+      "limit": 2
+    }]
+  ]
+}
+```
+
+### selectDistinct in Subqueries
+
+Use `selectDistinct` to get unique values from a subquery:
+
+```json
+{
+  "select": ["?name", "?email"],
+  "where": [
+    {"schema:name": "?name"},
+    ["query", {
+      "selectDistinct": ["?email"],
+      "where": {"schema:email": "?email"}
+    }]
+  ]
+}
+```
+
+### Multiple Subqueries
+
+You can have multiple subqueries in the same where clause:
+
+```json
+{
+  "select": ["?age", "?favNums"],
+  "where": [
+    ["query", {"select": ["?age"], "where": {"schema:age": "?age"}}],
+    ["query", {"select": ["?favNums"], "where": {"ex:favNums": "?favNums"}}]
+  ]
+}
+```
+
+### Nested Subqueries
+
+Subqueries can be nested within other subqueries:
+
+```json
+{
+  "select": ["?name", "?email", "?age"],
+  "where": [
+    {"schema:name": "?name"},
+    ["query", {
+      "selectDistinct": ["?age", "?email"],
+      "where": [
+        {"schema:age": "?age"},
+        ["query", {"select": ["?email"], "where": {"schema:email": "?email"}}]
+      ]
+    }]
+  ]
+}
+```
+
+### Subqueries in Union
+
+Subqueries can be used inside union operations:
+
+```json
+{
+  "select": ["?person", "?avgFavNum"],
+  "where": [
+    ["union",
+      ["query", {
+        "where": {"@id": "ex:alice", "ex:favNums": "?favN"},
+        "select": ["(as (str \"Alice\") ?person)", "(as (avg ?favN) ?avgFavNum)"]
+      }],
+      ["query", {
+        "where": {"@id": "ex:bob", "ex:favNums": "?favN"},
+        "select": ["(as (str \"Bob\") ?person)", "(as (avg ?favN) ?avgFavNum)"]
+      }]
+    ]
+  ]
+}
+```
+
+## Time Travel in Queries
+
+Fluree supports querying historical data using time travel syntax in the `from` clause. This allows you to query the database as it existed at a specific point in time.
+
+### Syntax
+
+Append a time specifier to the ledger name using `@`:
+
+| Syntax | Description | Example |
+| ------ | ----------- | ------- |
+| `ledger@t:N` | Query at transaction number N | `"myLedger@t:5"` |
+| `ledger@iso:TIMESTAMP` | Query at ISO-8601 timestamp | `"myLedger@iso:2024-01-15T10:30:00Z"` |
+| `ledger@sha:HASH` | Query at commit SHA | `"myLedger@sha:bafyrei..."` |
+
+### Query at Transaction Number
+
+Query the state of the ledger at a specific transaction:
+
+```json
+{
+  "from": "myLedger@t:5",
+  "select": ["?s", "?name"],
+  "where": {"@id": "?s", "schema:name": "?name"}
+}
+```
+
+This returns data as it existed after transaction 5.
+
+### Query at ISO-8601 Timestamp
+
+Query the state of the ledger at a specific point in time:
+
+```json
+{
+  "from": "myLedger@iso:2024-06-15T14:30:00Z",
+  "select": ["?s", "?name"],
+  "where": {"@id": "?s", "schema:name": "?name"}
+}
+```
+
+If the timestamp falls between transactions, Fluree returns the state as of the most recent transaction before that time.
+
+### Query at Commit SHA
+
+Query the state at a specific commit using its SHA hash:
+
+```json
+{
+  "from": "myLedger@sha:bafyreib",
+  "select": ["?s", "?name"],
+  "where": {"@id": "?s", "schema:name": "?name"}
+}
+```
+
+SHA prefixes must be at least 6 characters. You can use the full SHA or a unique prefix.
+
+### With Branch Specification
+
+Combine branch and time travel:
+
+```json
+{
+  "from": "myLedger:main@t:10",
+  "select": ["?s", "?name"],
+  "where": {"@id": "?s", "schema:name": "?name"}
+}
+```
+
+## Value Map Filters
+
+In addition to using `filter` as a where operation, you can apply filters directly inline within where conditions using value maps. This provides a more compact syntax for simple filtering.
+
+### Syntax
+
+```json
+{
+  "propertyName": {"@value": "?variable", "@filter": "expression"}
+}
+```
+
+Or using context aliases:
+
+```json
+{
+  "@context": {"value": "@value", "filter": "@filter"},
+  "where": {
+    "schema:age": {"value": "?age", "filter": "(> ?age 45)"}
+  }
+}
+```
+
+### Example
+
+Filter inline while binding variables:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ex": "http://example.org/",
+    "value": "@value",
+    "filter": "@filter"
+  },
+  "select": ["?name", "?last"],
+  "where": {
+    "@type": "ex:User",
+    "schema:age": {"value": "?age", "filter": "(> ?age 45)"},
+    "schema:name": "?name",
+    "ex:last": {"value": "?last", "filter": "(strEnds ?last \"ith\")"}
+  }
+}
+```
+
+This is equivalent to:
+
+```json
+{
+  "select": ["?name", "?last"],
+  "where": [
+    {"@type": "ex:User", "schema:age": "?age", "schema:name": "?name", "ex:last": "?last"},
+    ["filter", "(> ?age 45)", "(strEnds ?last \"ith\")"]
+  ]
+}
+```
+
+## Federated Queries (Multi-Ledger)
+
+Fluree supports querying across multiple ledgers in a single query. This is useful for:
+- Distributed data across microservices
+- Separating concerns (users, products, orders in different ledgers)
+- Combining data from multiple sources
+
+### Combined Datasets (`from` with Array)
+
+When you provide an array of ledger names to `from`, the ledgers are merged into a single unified graph:
+
+```json
+{
+  "@context": "https://schema.org",
+  "from": ["test/authors", "test/books", "test/movies"],
+  "select": ["?movieName", "?authorName"],
+  "where": {
+    "@type": "Movie",
+    "name": "?movieName",
+    "isBasedOn": {
+      "author": {"name": "?authorName"}
+    }
+  }
+}
+```
+
+In this mode:
+- All data is merged as if it were in one ledger
+- Entities with the same `@id` across ledgers are unified
+- You can traverse relationships that span ledgers
+
+### Named Graphs (`from-named` with `graph`)
+
+For more control, use `from-named` with explicit `graph` clauses to query ledgers separately:
+
+```json
+{
+  "@context": "https://schema.org",
+  "from-named": ["test/authors", "test/books", "test/movies"],
+  "select": ["?movieName", "?bookIsbn", "?authorName"],
+  "where": [
+    ["graph", "test/movies", {
+      "@id": "?movie",
+      "@type": "Movie",
+      "name": "?movieName",
+      "isBasedOn": "?book"
+    }],
+    ["graph", "test/books", {
+      "@id": "?book",
+      "isbn": "?bookIsbn",
+      "author": "?author"
+    }],
+    ["graph", "test/authors", {
+      "@id": "?author",
+      "name": "?authorName"
+    }]
+  ]
+}
+```
+
+In this mode:
+- Each ledger is kept separate
+- You explicitly specify which ledger to query with `["graph", "ledger-name", {...}]`
+- Variables bind across graph clauses to join data
+
+### Graph Clause Syntax
+
+```json
+["graph", "ledger-name", { ...where pattern... }]
+```
+
+The graph clause takes:
+1. The string `"graph"`
+2. The ledger name
+3. A where pattern to match in that ledger
+
+### Time Travel with Federated Queries
+
+You can combine time travel with federated queries:
+
+```json
+{
+  "from-named": ["ledger1@t:5", "ledger2@iso:2024-01-01T00:00:00Z"],
+  "select": ["?s", "?value"],
+  "where": [
+    ["graph", "ledger1@t:5", {"@id": "?s", "value": "?value"}]
+  ]
+}
+```
+
+## Vector Search
+
+Fluree supports vector similarity search for AI/ML applications like semantic search, recommendations, and embeddings.
+
+### Vector Datatype
+
+Store vectors using the `f:Vector` datatype:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "f": "https://ns.flur.ee/ledger#"
+  },
+  "insert": {
+    "@id": "ex:document1",
+    "ex:embedding": {
+      "@value": [0.6, 0.5, 0.3, 0.8],
+      "@type": "f:Vector"
+    }
+  }
+}
+```
+
+### Similarity Functions
+
+Use these functions in `bind` expressions to compute similarity scores:
+
+| Function | Description | Range |
+|----------|-------------|-------|
+| `dotProduct` | Dot product of two vectors | Unbounded |
+| `cosineSimilarity` | Cosine similarity (angle-based) | 0 to 1 |
+| `euclidianDistance` | Euclidean distance | 0 to infinity (lower = more similar) |
+
+### Basic Vector Search
+
+Find similar vectors using `values` to inject a target vector:
+
+```json
+{
+  "@context": {"ex": "http://example.org/", "f": "https://ns.flur.ee/ledger#"},
+  "select": ["?doc", "?score"],
+  "values": ["?targetVec", [{"@value": [0.7, 0.6, 0.4, 0.9], "@type": "f:Vector"}]],
+  "where": [
+    {"@id": "?doc", "ex:embedding": "?vec"},
+    ["bind", "?score", "(cosineSimilarity ?vec ?targetVec)"]
+  ],
+  "orderBy": "(desc ?score)"
+}
+```
+
+### Filtering by Score
+
+Add a filter to only return results above a similarity threshold:
+
+```json
+{
+  "@context": {"ex": "http://example.org/", "f": "https://ns.flur.ee/ledger#"},
+  "select": ["?doc", "?score"],
+  "values": ["?targetVec", [{"@value": [0.7, 0.6], "@type": "f:Vector"}]],
+  "where": [
+    {"@id": "?doc", "ex:embedding": "?vec"},
+    ["bind", "?score", "(cosineSimilarity ?vec ?targetVec)"],
+    ["filter", "(> ?score 0.8)"]
+  ]
+}
+```
+
+### Combining with Other Filters
+
+Filter by metadata before computing similarity:
+
+```json
+{
+  "@context": {"ex": "http://example.org/", "f": "https://ns.flur.ee/ledger#"},
+  "select": ["?doc", "?score", "?title"],
+  "values": ["?targetVec", [{"@value": [0.7, 0.6], "@type": "f:Vector"}]],
+  "where": [
+    {"@id": "?doc", "ex:embedding": "?vec", "ex:category": "technology", "ex:title": "?title"},
+    ["bind", "?score", "(cosineSimilarity ?vec ?targetVec)"]
+  ],
+  "orderBy": "(desc ?score)",
+  "limit": 10
+}
+```
+
+### Best Practices
+
+1. **Normalize vectors** — Especially for cosine similarity, normalized vectors give more consistent results
+2. **Use appropriate dimensions** — Match your embedding model's output dimension
+3. **Filter first** — Apply metadata filters before vector operations to reduce computation
+4. **Limit results** — Vector search over large datasets should use `limit` for performance
+
+## Next Steps
+
+- [FlureeQL Overview](../) — Query syntax summary
+- [Full-Text Search](/docs/reference/full-text-search) — Text-based search
+- [History Queries](/docs/reference/history-syntax) — Query data changes over time

--- a/docs/reference/querying/aggregations.mdx
+++ b/docs/reference/querying/aggregations.mdx
@@ -1,0 +1,180 @@
+import Admonition from "@theme/Admonition";
+
+# Aggregations & Grouping
+
+Group query results and compute aggregate values like counts, sums, and averages.
+
+## `groupBy`
+
+| required? | type                |
+| --------- | ------------------- |
+| no        | `array` or `string` |
+
+The `groupBy` clause lets you group query results by a predicate and perform
+aggregate operations on the groups.
+
+For example, let's say you have a query that returns the name and company for
+all people in your database, and the results look like this:
+
+```json
+[
+  {
+    "ex:company": "Fluree",
+    "ex:name": "Letitia"
+  },
+  {
+    "ex:company": "Fluree",
+    "ex:name": "Freddy"
+  },
+  {
+    "ex:company": "Beep Boop",
+    "ex:name": "Daniel"
+  }
+]
+```
+
+You could group these results by `ex:company` to see who works for each company:
+
+```json
+{
+  "@context": { "ex": "http://example.org/" },
+  "select": ["?company", "?name"],
+  "where": {
+    "@id": "?s",
+    "ex:name": "?name",
+    "ex:company": "?company"
+  },
+  "groupBy": "?company"
+}
+```
+
+This would return:
+
+```json
+[
+  ["Fluree", ["Letitia", "Freddy"]],
+  ["Beep Boop", ["Daniel"]]
+]
+```
+
+You can also perform aggregate operations on the grouped data. These operations
+let you answers questions like, "how many people are employed at each company?"
+or "what is the lowest price that a product has sold for?"
+
+If you wanted to get a count of people per employer, you could write a query like this:
+
+```json
+{
+  "@context": { "ex": "http://example.org/" },
+  "select": ["?company", "(count ?s)"],
+  "where": {
+    "@id": "?s",
+    "ex:name": "?name",
+    "ex:company": "?company"
+  },
+  "groupBy": "?company"
+}
+```
+
+And you would get results like this:
+
+```json
+[
+  ["Fluree", 2],
+  ["Beep Boop", 1]
+]
+```
+
+## `having`
+
+| required? | type                |
+| --------- | ------------------- |
+| no        | `array` or `string` |
+
+Having lets you filter on grouped data using arbitrary expressions.
+
+> **NOTE**: `having` is only valid when used with `groupBy`.
+
+```json
+{
+  "@context": { "ex": "http://example.org/", "schema": "http://schema.org/" },
+  "select": ["?name", "?favNums"],
+  "where": {
+    "@id": "?s",
+    "schema:name": "?name",
+    "ex:favNums": "?favNums"
+  },
+  "groupBy": "?name",
+  "having": "(>= (avg ?favNums) 10)"
+}
+```
+
+As English, this query would read: _"Find all entities with names and favorite numbers. Group the results by name. Keep only results where the average of all `?favNums` for a `?name` is greater than or equal to `10`."_
+
+> If we had used a `filter` function without `groupBy`, then we would have been filtering on the average of **all `favNum` values across all entities**. By using, `groupBy` & `having`, we can filter on the average of only those values grouped to a particular `?name`.
+
+## Aggregate Functions
+
+Aggregate functions compute values across multiple results. They are used in the `select` clause and are typically combined with `groupBy` to compute aggregates per group.
+
+### Available Aggregates
+
+| function        | description                          | example                  |
+| --------------- | ------------------------------------ | ------------------------ |
+| `count`         | Count of values                      | `(count ?s)`             |
+| `sum`           | Sum of numeric values                | `(sum ?price)`           |
+| `avg`           | Average of numeric values            | `(avg ?age)`             |
+| `min`           | Minimum value                        | `(min ?date)`            |
+| `max`           | Maximum value                        | `(max ?salary)`          |
+| `sample`        | Random sample from values            | `(sample ?name)`         |
+| `group_concat`  | Concatenate values into string       | `(group_concat ?tag)`    |
+
+### Count Example
+
+```json
+{
+  "select": ["(count ?s)"],
+  "where": { "@id": "?s", "@type": "ex:Person" }
+}
+```
+
+Returns: `[[42]]` (if there are 42 Person entities)
+
+### Grouped Aggregates
+
+```json
+{
+  "select": ["?department", "(count ?employee)", "(avg ?salary)"],
+  "where": {
+    "@id": "?employee",
+    "ex:department": "?department",
+    "ex:salary": "?salary"
+  },
+  "groupBy": "?department"
+}
+```
+
+Returns results like:
+```json
+[
+  ["Engineering", 25, 95000],
+  ["Sales", 15, 75000],
+  ["Marketing", 10, 70000]
+]
+```
+
+### Multiple Aggregates
+
+You can use multiple aggregate functions in a single query:
+
+```json
+{
+  "select": ["(count ?s)", "(sum ?price)", "(avg ?price)", "(min ?price)", "(max ?price)"],
+  "where": { "@id": "?s", "ex:price": "?price" }
+}
+```
+
+## Next Steps
+
+- [Modifiers](../modifiers/) — Order, limit, and paginate results
+- [Advanced Features](../advanced-features/) — Property paths, subqueries, and more

--- a/docs/reference/querying/index.mdx
+++ b/docs/reference/querying/index.mdx
@@ -1,0 +1,153 @@
+import Admonition from "@theme/Admonition";
+
+# FlureeQL Query Syntax
+
+<div class="overview">
+  FlureeQL is a JSON-based query language for retrieving Fluree data. It is
+  modeled as a JSON-representation of the W3C SPARQL standard.
+</div>
+
+---
+
+## Query Object
+
+FlureeQL queries are JSON with the following keys:
+
+| key                        | required? | type                  |
+| -------------------------- | --------- | --------------------- |
+| [`@context`](#context)     | no        | `object`              |
+| [`from`](#from)            | yes       | `string` or `array`   |
+| [`where`](./where-clauses) | no        | `array` or `object`   |
+| [`select`](./select-clauses) | yes*    | `array` or `object`   |
+| [`construct`](./select-clauses#construct) | no* | `array`       |
+| [`values`](./modifiers#values) | no    | `array`               |
+| [`t`](./modifiers#t)       | no        | `string` or `integer` |
+| [`groupBy`](./aggregations#groupby) | no | `array` or `string` |
+| [`having`](./aggregations#having) | no | `array` or `string`   |
+| [`orderBy`](./modifiers#orderby) | no  | `string` or `array`   |
+| [`limit`](./modifiers#limit) | no      | `integer`             |
+| [`offset`](./modifiers#offset) | no    | `integer`             |
+
+> **NOTE**: Either `select` or `construct` is required, but not both.
+
+### Advanced Features
+
+| Feature | Description |
+| ------- | ----------- |
+| [Property Paths](./advanced-features#property-paths-transitive-queries) | Traverse relationships across multiple hops |
+| [Subqueries](./advanced-features#subqueries) | Nest queries within queries |
+| [Time Travel](./advanced-features#time-travel-in-queries) | Query historical data using `@t:`, `@iso:`, or `@sha:` syntax |
+| [Value Map Filters](./advanced-features#value-map-filters) | Inline filters in where conditions |
+| [Federated Queries](./advanced-features#federated-queries-multi-ledger) | Query across multiple ledgers |
+| [Vector Search](./advanced-features#vector-search) | Similarity search with embeddings |
+
+### Examples
+
+<details>
+<summary>Basic query example</summary>
+```json
+{
+  "from": "cookbook/base",
+  "where": {
+    "@id": "?s",
+    "bestFriend": "?friend"
+  },
+  "select": {
+    "?s": [
+      "*",
+      {
+        "bestFriend": [
+          "*"
+        ]
+      }
+    ]
+  },
+}
+```
+</details>
+
+## `@context`
+
+| required? | type     |
+| --------- | -------- |
+| no        | `object` |
+
+Understanding the use of `@context` within the W3C JSON-LD standard can be important for using it properly within queries. For an explanation of how to use `@context` in FlureeQL, consider first reading our [Guides page on Working with Context](/docs/learn/working-with-data/context-patterns/).
+
+### Examples
+
+<details>
+<summary>Example of a Query without `@context`</summary>
+
+```json
+{
+  "from": "cookbook/base",
+  "where": {
+    "@id": "?s",
+    "@type": "http://example.org/Person"
+  },
+  "select": {
+    "?s": ["http://schema.org/name"]
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Example of a Query with `@context`</summary>
+
+```json
+{
+  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
+  "from": "cookbook/base",
+  "where": {
+    "@id": "?s",
+    "@type": "ex:Person"
+  },
+  "select": {
+    "?s": ["schema:name"]
+  }
+}
+```
+
+</details>
+
+## `from`
+
+| required? | type     |
+| --------- | -------- |
+| yes       | `string` |
+
+The `from` clause specifies the ledger to query. It takes the same value that would have been supplied to the `/create` endpoint when the ledger was created.
+
+If I named a ledger `"cookbook/base"` when I created it, then when I queried it, I would use `"from": "cookbook/base"` to identify that this query should target that particular ledger.
+
+### Examples
+
+<details>
+<summary>Querying a ledger named `"cookbook/base"`</summary>
+
+```json
+{
+  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
+  "from": "cookbook/base",
+  "where": {
+    "@id": "?s",
+    "@type": "ex:Person"
+  },
+  "select": {
+    "?s": ["schema:name"]
+  }
+}
+```
+
+</details>
+
+## Next Steps
+
+- [Select Clauses](./select-clauses) — Control what data is returned
+- [Where Clauses](./where-clauses) — Filter and match data patterns
+- [Aggregations & Grouping](./aggregations) — Group and aggregate results
+- [Modifiers](./modifiers) — Order, limit, and paginate results
+- [Advanced Features](./advanced-features) — Property paths, subqueries, federated queries, and more

--- a/docs/reference/querying/modifiers.mdx
+++ b/docs/reference/querying/modifiers.mdx
@@ -1,0 +1,197 @@
+import Admonition from "@theme/Admonition";
+
+# Query Modifiers
+
+Modifiers control how query results are ordered, limited, and paginated.
+
+## `orderBy`
+
+| required? | type                |
+| --------- | ------------------- |
+| no        | `string` or `array` |
+
+The `orderBy` clause sorts query results by one or more variables. By default, results are sorted in ascending order.
+
+### Basic Ordering
+
+To sort by a single variable in ascending order, use the variable name directly:
+
+```json
+{
+  "select": ["?s", "?name"],
+  "where": { "@id": "?s", "schema:name": "?name" },
+  "orderBy": "?name"
+}
+```
+
+### Direction Functions
+
+To specify sort direction explicitly, use the `(asc ?var)` or `(desc ?var)` function syntax:
+
+```json
+{
+  "select": ["?s", "?name"],
+  "where": { "@id": "?s", "schema:name": "?name" },
+  "orderBy": "(desc ?name)"
+}
+```
+
+### Multiple Sort Criteria
+
+To sort by multiple variables, use an array of variables or direction functions:
+
+```json
+{
+  "select": ["?s", "?lastName", "?firstName"],
+  "where": { "@id": "?s", "schema:familyName": "?lastName", "schema:givenName": "?firstName" },
+  "orderBy": ["?lastName", "(desc ?firstName)"]
+}
+```
+
+## `limit`
+
+| required? | type      |
+| --------- | --------- |
+| no        | `integer` |
+
+The `limit` clause restricts the number of results returned by a query. This is useful for pagination or when you only need a subset of results.
+
+```json
+{
+  "select": ["?s", "?name"],
+  "where": { "@id": "?s", "schema:name": "?name" },
+  "limit": 10
+}
+```
+
+## `offset`
+
+| required? | type      |
+| --------- | --------- |
+| no        | `integer` |
+
+The `offset` clause skips a number of results before returning. Combined with `limit`, this enables pagination through large result sets.
+
+```json
+{
+  "select": ["?s", "?name"],
+  "where": { "@id": "?s", "schema:name": "?name" },
+  "limit": 10,
+  "offset": 20
+}
+```
+
+This query would return results 21-30 (skipping the first 20).
+
+## `values`
+
+| required? | type    |
+| --------- | ------- |
+| no        | `array` |
+
+The `values` clause lets you inject specific values into a query, constraining a logic variable to a predefined set of values. This is similar to SQL's `IN` clause.
+
+### Single Variable
+
+To bind a single variable to a set of values:
+
+```json
+{
+  "select": ["?s", "?name"],
+  "where": { "@id": "?s", "schema:name": "?name" },
+  "values": ["?name", ["Alice", "Bob", "Charlie"]]
+}
+```
+
+This query will only return results where `?name` is one of "Alice", "Bob", or "Charlie".
+
+### Multiple Variables
+
+To bind multiple variables simultaneously, provide arrays of variable names and value tuples:
+
+```json
+{
+  "select": ["?s", "?firstName", "?lastName"],
+  "where": {
+    "@id": "?s",
+    "schema:givenName": "?firstName",
+    "schema:familyName": "?lastName"
+  },
+  "values": [
+    ["?firstName", "?lastName"],
+    [
+      ["Alice", "Smith"],
+      ["Bob", "Jones"],
+      ["Charlie", "Brown"]
+    ]
+  ]
+}
+```
+
+## `t`
+
+| required? | type                  |
+| --------- | --------------------- |
+| no        | `string` or `integer` |
+
+The `t` clause lets you specify a dateTime value or commit number to query against. We refer to this as a "time-traveling" query.
+
+The `t` clause can take two possible values, an **ISO 8601 dateTime string** (expressing a particular moment in time according to the database state), or a **commit integer** (expressing a particular relative commit number in the history of the ledger).
+
+<Admonition type="info">
+Note that, while a commit integer expresses an actual moment of data state change, an ISO dateTime string likely expresses a moment in-between commits. The use of an ISO dateTime string, then, expresses an interest in the data state as of that moment in time.
+
+That is, if commit #1 took place at `'2023-10-30T12:43:38.452Z'` and commit #2 took place 10 minutes later at `'2023-10-30T12:53:38.452Z'`, then a query for a dateTime moment in the middle of those two commits, e.g. `"t": '2023-10-30T12:48:38.452Z'`, would reflect the data state as of commit #1.
+
+</Admonition>
+
+### Using ISO 8601 Timestamp
+
+```json
+{
+  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
+  "where": {
+    "@id": "?s",
+    "@type": "ex:Yeti",
+    "schema:age": "?age"
+  },
+  "select": ["?s", "?age"],
+  "t": "2023-10-30T12:38:45.389Z"
+}
+```
+
+### Using Commit Number
+
+```json
+{
+  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
+  "where": {
+    "@id": "?s",
+    "@type": "ex:Yeti",
+    "schema:age": "?age"
+  },
+  "select": ["?s", "?age"],
+  "t": 4
+}
+```
+
+## Pagination Example
+
+Combine `orderBy`, `limit`, and `offset` for pagination:
+
+```json
+{
+  "select": ["?s", "?name", "?createdAt"],
+  "where": { "@id": "?s", "schema:name": "?name", "ex:createdAt": "?createdAt" },
+  "orderBy": "(desc ?createdAt)",
+  "limit": 25,
+  "offset": 50
+}
+```
+
+This returns page 3 (items 51-75) of results sorted by newest first.
+
+## Next Steps
+
+- [Advanced Features](../advanced-features/) — Property paths, subqueries, federated queries, and more
+- [FlureeQL Overview](../) — Query syntax summary

--- a/docs/reference/querying/select-clauses.mdx
+++ b/docs/reference/querying/select-clauses.mdx
@@ -1,0 +1,259 @@
+import Admonition from "@theme/Admonition";
+
+# Select Clauses
+
+The `select` clause determines what data is returned from a query. It defines the shape of your results.
+
+## `select`
+
+| required? | type                |
+| --------- | ------------------- |
+| yes       | `array` or `object` |
+
+A select can be either a [_select object_](#select-object) or a [_select
+array_](#select-array).
+
+### Select Object
+
+With a select object, each key is a [_logic variable
+name_](#logic-variable-name) and the value is an array of [_select
+expressions_](#select-expression).
+
+The select clause determines what objects are returned in query results. Each
+logic variable corresponds to a set of subjects, and a JSON object gets
+constructed for each subject. The array of select expressions describes how to
+build these JSON objects by specifying what predicates to include.
+
+### Select Object Examples
+
+<details>
+<summary>Simple `select` example</summary>
+```json focus=2:7
+{
+  "select": {
+    "?s": [
+      "name",
+      { "bestFriend": ["*"] }
+    ]
+  },
+  "where": {
+    "@id": "?s",
+    "bestFriend": "?friend"
+  }
+}
+```
+</details>
+
+### Select Array
+
+With a select array, each element is a [_logic variable
+name_](#logic-variable-name) or a [_select
+object_](#select-object). When your select clause is a select array, each element of the query
+results is an array.
+
+### Select Array Examples
+
+<details>
+<summary>Logic variable</summary>
+```json focus=2
+{
+  "select": ["?s", "?name", "?friend"],
+  "where": {
+    "@id": "?s",
+    "bestFriend": "?friend",
+    "name": "?name"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Logic variable and a select object</summary>
+```json focus=2:5
+{
+  "select": [
+    { "?s": ["*"] },
+    { "?friend": ["*"] }
+  ],
+  "where": {
+    "@id": "?s",
+    "bestFriend": "?friend",
+    "name": "?name"
+  }
+}
+```
+</details>
+
+## Logic Variable Name
+
+Logic variables are placeholders for sets of subjects. They are identified by
+_logic variable names_.
+
+Logic variable names are strings that begin with a question mark, `?`, followed
+by alphanumeric characters, hyphens, and underscores.
+
+See [Querying Basics](/docs/learn/working-with-data/querying-basics/) for
+information about logic variables.
+
+### Examples
+
+```json
+"?firstname"
+"?first-name"
+"?first_name"
+"?address-1"
+```
+
+## Select Expression
+
+Select clause objects map _logic variables_ to _select expressions_. In the
+select clause below, `"?s"` identifies a logic variable and `["name", {
+"bestFriend": ["*"] }]` is a select expression.
+
+```json focus=2:7
+{
+  "select": {
+    "?s": [
+      "name",
+      { "bestFriend": ["*"] }
+    ]
+  },
+  "where": { ... }
+}
+```
+
+Select expressions describe the shape of data to be returned for subjects. It
+specifies what predicates to include in the result object, and how to traverse
+predicates to return nested values.
+
+A select expression can be one of:
+
+- A predicate, like `"schema:name"`. When included, the corresponding value
+  is returned in the result object.
+- The wildcard symbol, `"*"`. When included, all of a subject's predicates are
+  included in its result object.
+- A [_node object template_](#node-object-template). This describes how to
+  traverse nested predicate values.
+
+### Examples
+
+```json
+// wildcard
+"*"
+
+// predicate
+"schema:name"
+
+// node object template; see below
+{
+   "schema:address": ["*"]
+}
+```
+
+## Node Object Template
+
+Node object templates are objects where the keys are predicates, and the values
+are arrays of select expressions. Node object templates express _for the given
+predicate, construct an object that contains the predicates described by the
+array of select expressions._
+
+```json
+{
+  predicate: [select-expression, select-expression, ...],
+  predicate: [select-expression, select-expression, ...],
+  ...
+}
+```
+
+### Examples
+
+<details>
+<summary>Return an object that has all predicates for the node that `"bestFriend"` refers to</summary>
+
+```json focus=2:6
+{
+  "select": {
+    "?s": [
+      { "bestFriend": ["*"] }
+    ]
+  },
+  "where": { ... }
+}
+```
+
+</details>
+
+<details>
+<summary>Multi-level nested object</summary>
+```json focus=4:12
+{
+  "select": {
+    "?s": [
+      {
+        "bestFriend": [
+          {
+            "address": [
+              "*"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "where": { ... }
+}
+```
+</details>
+
+## `construct`
+
+| required? | type    |
+| --------- | ------- |
+| no*       | `array` |
+
+The `construct` clause builds custom JSON-LD output from query results, similar to SPARQL CONSTRUCT queries. Use `construct` instead of `select` when you want to transform query results into a specific shape.
+
+> **NOTE**: Either `select` or `construct` is required, but not both.
+
+### Basic Construct
+
+```json
+{
+  "from": "my-ledger",
+  "construct": [
+    {
+      "@id": "?s",
+      "@type": "ex:SearchResult",
+      "ex:displayName": "?name"
+    }
+  ],
+  "where": { "@id": "?s", "schema:name": "?name" }
+}
+```
+
+### Example Response
+
+```json
+{
+  "@graph": [
+    {
+      "@id": "ex:alice",
+      "@type": ["ex:SearchResult"],
+      "ex:displayName": ["Alice"]
+    },
+    {
+      "@id": "ex:bob",
+      "@type": ["ex:SearchResult"],
+      "ex:displayName": ["Bob"]
+    }
+  ]
+}
+```
+
+The `construct` clause returns a JSON-LD document with an `@graph` array containing the constructed nodes.
+
+## Next Steps
+
+- [Where Clauses](../where-clauses/) — Filter and match data patterns
+- [Aggregations & Grouping](../aggregations/) — Group and aggregate results

--- a/docs/reference/querying/where-clauses.mdx
+++ b/docs/reference/querying/where-clauses.mdx
@@ -1,376 +1,8 @@
 import Admonition from "@theme/Admonition";
 
-# FlureeQL Query Syntax
+# Where Clauses
 
-<div class="overview">
-  FlureeQL is a JSON-based query language for retrieving Fluree data. It is
-  modeled as a JSON-representation of the W3C SPARQL standard.
-</div>
-
----
-
-## Query Object
-
-FlureeQL queries are JSON with the following keys:
-
-| key                    | required? | type                  |
-| ---------------------- | --------- | --------------------- |
-| [`@context`](#context) | no        | `object`              |
-| [`from`](#from)        | yes       | `string` or `array`   |
-| [`where`](#where)      | no        | `array` or `object`   |
-| [`select`](#select)    | yes       | `array` or `object`   |
-| [`t`](#t)              | no        | `string` or `integer` |
-| [`groupBy`](#groupby)  | no        | `array` or `string`   |
-| [`having`](#having)    | no        | `array` or `string`   |
-| `orderBy`              | no        | `string`              |
-
-### Examples
-
-<details>
-<summary>Basic query example</summary>
-```json
-{
-  "from": "cookbook/base",
-  "where": {
-    "@id": "?s",
-    "bestFriend": "?friend"
-  },
-  "select": {
-    "?s": [
-      "*",
-      {
-        "bestFriend": [
-          "*"
-        ]
-      }
-    ]
-  },
-}
-```
-</details>
-
-## `@context`
-
-| required? | type     |
-| --------- | -------- |
-| no        | `object` |
-
-Understanding the use of `@context` within the W3C JSON-LD standard can be important for using it properly within queries. For an explanation of how to use `@context` in FlureeQL, consider first reading our [Guides page on Working with Context](/docs/learn/guides/working-with-context/).
-
-    {/*
-
-If you do not use the `@context` key within a query, Fluree will fall back to any `defaultContext` that has been set for the ledger. If no `defaultContext` has been set, then Fluree will expect the query to use fully-qualified IRIs for any entities, properties, or `@type` values.
-
-<Admonition type="info">
-  If you **do** have a `defaultContext` set for your ledger but you wish to use
-  fully-qualified IRIs in your query, you can do so by setting the `@context`
-  key to `null`
-</Admonition>
-
-You can either **replace** or **extend** the `defaultContext` by using the `@context` key in your query.
-
-The following use of `@context` will ignore a `defaultContext` and replace it with the provided map.
-
-```json
-{
-  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
-  ...
-}
-```
-
-Whereas this next use of `@context` will leverage a `defaultContext` and extend it with the provided map.
-
-```json
-{
-  "@context": ["", { "schema": "http://schema.org/", "ex": "http://example.org/" }],
-  ...
-}
-```
-
-<Admonition type="info">
-  Note that the first element of the array is an _empty string_. This is a
-  shorthand similar to a _relative path_ -- it indicates that there is a
-  `defaultContext` local to the ledger that should be used as a base. The map
-  following the _empty string_ should then be used to extend the
-  `defaultContext`.
-</Admonition>
-
-\*/}
-
-### Examples
-
-<details>
-<summary>Example of a Query without `@context`</summary>
-
-```json
-{
-  "from": "cookbook/base",
-  "where": {
-    "@id": "?s",
-    "@type": "http://example.org/Person"
-  },
-  "select": {
-    "?s": ["http://schema.org/name"]
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Example of a Query with `@context`</summary>
-
-```json
-{
-  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
-  "from": "cookbook/base",
-  "where": {
-    "@id": "?s",
-    "@type": "ex:Person"
-  },
-  "select": {
-    "?s": ["schema:name"]
-  }
-}
-```
-
-</details>
-
-## `from`
-
-| required? | type     |
-| --------- | -------- |
-| yes       | `string` |
-
-The `from` clause specifies the ledger to query. It takes the same value that would have been supplied to the `/create` endpoint when the ledger was created.
-
-If I named a ledger `"cookbook/base"` when I created it, then when I queried it, I would use `"from": "cookbook/base"` to identify that this query should target that particular ledger.
-
-### Examples
-
-<details>
-<summary>Querying a ledger named `"cookbook/base"`</summary>
-
-```json
-{
-  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
-  "from": "cookbook/base",
-  "where": {
-    "@id": "?s",
-    "@type": "ex:Person"
-  },
-  "select": {
-    "?s": ["schema:name"]
-  }
-}
-```
-
-</details>
-
-## `select`
-
-| required? | type                |
-| --------- | ------------------- |
-| yes       | `array` or `object` |
-
-A select can be either a [_select object_](#select-object) or a [_select
-array_](#select-array).
-
-### Select Object
-
-With a select object, each key is a [_logic variable
-name_](#logic-variable-name) and the value is an array of [_select
-expressions_](#select-expression).
-
-The select clause determines what objects are returned in query results. Each
-logic variable corresponds to a set of subjects, and a JSON object gets
-constructed for each subject. The array of select expressions describes how to
-build these JSON objects by specifying what predicates to include.
-
-### Select Object Examples
-
-<details>
-<summary>Simple `select` example</summary>
-```json focus=2:7
-{
-  "select": {
-    "?s": [
-      "name",
-      { "bestFriend": ["*"] }
-    ]
-  },
-  "where": {
-    "@id": "?s",
-    "bestFriend": "?friend"
-  }
-}
-
-````
-</details>
-
-### Select Array
-
-With a select array, each element is a [_logic variable
-name_](#logic-variable-name) or a [_select
-object_](#select-object). When your select clause is a select array, each element of the query
-results is an array.
-
-### Select Array Examples
-
-<details>
-<summary>Logic variable</summary>
-```json focus=2
-{
-  "select": ["?s", "?name", "?friend"],
-  "where": {
-    "@id": "?s",
-    "bestFriend": "?friend",
-    "name": "?name"
-  }
-}
-
-````
-
-</details>
-
-<details>
-<summary>Logic variable and a select object</summary>
-```json focus=2:5
-{
-  "select": [
-    { "?s": ["*"] },
-    { "?friend": ["*"] }
-  ],
-  "where": {
-    "@id": "?s",
-    "bestFriend": "?friend",
-    "name": "?name"
-  }
-}
-```
-</details>
-
-## Logic variable name
-
-Logic variables are placeholders for sets of subjects. They are identified by
-_logic variable names_.
-
-Logic variable names are strings that begin with a question mark, `?`, followed
-by alphanumeric characters, hyphens, and underscores.
-
-See [the tutorial section on
-queries](/docs/learn/tutorial/working-with-graph-data#a-simple-query) for
-information about logic variables.
-
-### Examples
-
-```json
-"?firstname"
-"?first-name"
-"?first_name"
-"?address-1"
-```
-
-## Select expression
-
-Select clause objects map _logic variables_ to _select expressions_. In the
-select clause below, `"?s"` identifies a logic variable and `["name", {
-"bestFriend": ["*"] }]` is a select expression.
-
-```json focus=2:7
-{
-  "select": {
-    "?s": [
-      "name",
-      { "bestFriend": ["*"] }
-    ]
-  },
-  "where": { ... }
-}
-```
-
-Select expressions describe the shape of data to be returned for subjects. It
-specifies what predicates to include in the result object, and how to traverse
-predicates to return nested values.
-
-A select expression can be one of:
-
-- A predicate, like `"schema:name"`. When included, the corresponding value
-  is returned in the result object.
-- The wildcard symbol, `"*"`. When included, all of a subject's predicates are
-  included in its result object.
-- A [_node object template_](#node-object-template). This describes how to
-  traverse nested predicate values.
-
-### Examples
-
-```json
-// wildcard
-"*"
-
-// predicate
-"schema:name"
-
-// node object template; see below
-{
-   "schema:address": ["*"]
-}
-```
-
-## Node object template
-
-Node object templates are objects where the keys are predicates, and the values
-are arrays of select expressions. Node object templates express _for the given
-predicate, construct an object that contains the predicates described by the
-array of select expressions._
-
-```json
-{
-  predicate: [select-expression, select-expression, ...],
-  predicate: [select-expression, select-expression, ...],
-  ...
-}
-```
-
-### Examples
-
-<details>
-<summary>Return an object that has all predicates for the node that `"bestFriend"` refers to</summary>
-
-```json focus=2:6
-{
-  "select": {
-    "?s": [
-      { "bestFriend": ["*"] }
-    ]
-  },
-  "where": { ... }
-}
-```
-
-</details>
-
-<details>
-<summary>Multi-level nested object</summary>
-```json focus=4:12
-{
-  "select": {
-    "?s": [
-      {
-        "bestFriend": [
-          {
-            "address": [
-              "*"
-            ]
-          }
-        ]
-      }
-    ]
-  },
-  "where": { ... }
-}
-```
-</details>
+The `where` clause filters data and establishes variable bindings for use in the `select` clause.
 
 ## `where`
 
@@ -389,7 +21,7 @@ In any case, in addition to establishing _logic variables_ for bound values, we 
 When a `where` clause is an _array_, it can combine a series of [_where conditions_](#where-condition) and [_where
 operations_](#where-operations).
 
-## Where condition
+## Where Condition
 
 A where condition describes relationships between nodes that must be satisfied for
 the nodes to be included in result sets, and it names those sets.
@@ -503,7 +135,7 @@ Finally, it is possible in _where conditions_ to express a _logic variable_ for 
 
 </details>
 
-## Where operations
+## Where Operations
 
 _Where operations_ allow you to express more complex behavior than _where
 conditions_. There are four such operations:
@@ -562,7 +194,7 @@ read as _`?age` is greater than `45`_.
 Inside of each _filter expression_, you can refer to the logic variables that you've bound elsewhere in your `where`
 clause (i.e. the way that we use `?age` as a variable in the example above).
 
-[Click here](#valid-functions-for-use-in-filter-and-bind-expressions) for a list of valid functions you can use in `filter` expressions.
+[See the full list of valid functions](#valid-functions-for-use-in-filter-and-bind-expressions) you can use in `filter` expressions.
 
 ### `union`
 
@@ -637,7 +269,7 @@ Like [`filter`](#filter) and [`union`](#union), `bind` is an array where the fir
 
 </details>
 
-[Click here](#valid-functions-for-use-in-filter-and-bind-expressions) for a list of valid functions you can use in `bind` expressions.
+[See the full list of valid functions](#valid-functions-for-use-in-filter-and-bind-expressions) you can use in `bind` expressions.
 
 ### `optional`
 
@@ -678,7 +310,7 @@ When we use `optional`, we are saying "if this triple exists, then bind the valu
 
 </Admonition>
 
-### Valid Functions for Use in Filter and Bind Expressions
+## Valid Functions for Use in Filter and Bind Expressions
 
 | function                  | description                                     | example                                         |
 | ------------------------- | ----------------------------------------------- | ----------------------------------------------- |
@@ -714,157 +346,11 @@ When we use `optional`, we are saying "if this triple exists, then bind the valu
 | `now`                     | returns the current time                        | `(> ?date (now))`                               |
 | `if`                      | conditional                                     | `(if (> ?nums 30) (> ?age 100) true)`           |
 | `isNumeric`               | returns true if value is numeric                | `(isNumeric ?age)`                              |
+| `in`                      | check if value is in a collection               | `(in ?x [1 2 3])`                               |
+| `str`                     | convert to string                               | `(str ?value)`                                  |
+| `as`                      | alias an expression (used in select with aggregates) | `(as (avg ?x) ?avgX)`                      |
 
-## `t`
+## Next Steps
 
-| required? | type                  |
-| --------- | --------------------- |
-| no        | `string` or `integer` |
-
-The `t` clause lets you specify a dateTime value or commit number to query against. We refer to this as a "time-traveling" query.
-
-The `t` clause can take two possible values, an **ISO 8601 dateTime string** (expressing a particular moment in time according to the database state), or a **commit integer** (expressing a particular relative commit number in the history of the ledger).
-
-<Admonition type="info">
-Note that, while a commit integer expresses an actual moment of data state change, an ISO dateTime string likely expresses a moment in-between commits. The use of an ISO dateTime string, then, expresses an interest in the data state as of that moment in time.
-
-That is, if commit #1 took place at `'2023-10-30T12:43:38.452Z'` and commit #2 took place 10 minutes later at `'2023-10-30T12:53:38.452Z'`, then a query for a dateTime moment in the middle of those two commits, e.g. `"t": '2023-10-30T12:48:38.452Z'`, would reflect the data state as of commit #1.
-
-</Admonition>
-
-```json focus=9
-{
-  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
-  "where": {
-    "@id": "?s",
-    "@type": "ex:Yeti",
-    "schema:age": "?age"
-  },
-  "select": ["?s", "?age"],
-  "t": "2023-10-30T12:38:45.389Z"
-}
-```
-
-Or the same query, but using a commit integer value for `t`:
-
-```json focus=9
-{
-  "@context": { "schema": "http://schema.org/", "ex": "http://example.org/" },
-  "where": {
-    "@id": "?s",
-    "@type": "ex:Yeti",
-    "schema:age": "?age"
-  },
-  "select": ["?s", "?age"],
-  "t": 4
-}
-```
-
-## `groupBy`
-
-| required? | type                |
-| --------- | ------------------- |
-| no        | `array` or `string` |
-
-The `groupBy` clause lets you group query results by a predicate and perform
-aggregate operations on the groups.
-
-For example, let's say you have a query that returns the name and company for
-all people in your database, and the results look like this:
-
-```json
-[
-  {
-    "ex:company": "Fluree",
-    "ex:name": "Letitia"
-  },
-  {
-    "ex:company": "Fluree",
-    "ex:name": "Freddy"
-  },
-  {
-    "ex:company": "Beep Boop",
-    "ex:name": "Daniel"
-  }
-]
-```
-
-You could group these results by `ex:company` to see who works for each company:
-
-```json
-{
-  "@context": { "ex": "http://example.org/" },
-  "select": ["?company", "?name"],
-  "where": {
-    "@id": "?s",
-    "ex:name": "?name",
-    "ex:company": "?company"
-  },
-  "groupBy": "?company"
-}
-```
-
-This would return:
-
-```json
-[
-  ["Fluree", ["Letitia", "Freddy"]],
-  ["Beep Boop", ["Daniel"]]
-]
-```
-
-You can also perform aggregate operations on the grouped data. These operations
-let you answers questions like, "how many people are employed at each company?"
-or "what is the lowest price that a product has sold for?"
-
-If you wanted to get a count of people per employer, you could write a query like this:
-
-```json
-{
-  "@context": { "ex": "http://example.org/" },
-  "select": ["?company", "(count ?s)"],
-  "where": {
-    "@id": "?s",
-    "ex:name": "?name",
-    "ex:company": "?company"
-  },
-  "groupBy": "?company"
-}
-```
-
-And you would get results like this:
-
-```json
-[
-  ["Fluree", 2],
-  ["Beep Boop", 1]
-]
-```
-
-## `having`
-
-| required? | type                |
-| --------- | ------------------- |
-| no        | `array` or `string` |
-
-Having lets you filter on grouped data using arbitrary expressions.
-
-> **NOTE**: `having` is only valid when used with `groupBy`.
-
-```json
-{
-  "@context": { "ex": "http://example.org/", "schema": "http://schema.org/" },
-  "select": ["?name", "?favNums"],
-  "where": {
-    "@id": "?s",
-    "schema:name": "?name",
-    "ex:favNums": "?favNums"
-  },
-  "groupBy": "?name",
-  "having": "(>= (avg ?favNums) 10)"
-}
-```
-
-As English, this query would read: _"Find all entities with names and favorite numbers. Group the results by name. Keep only results where the average of all `?favNums` for a `?name` is greater than or equal to `10`."_
-
-> If we had used a `filter` function without `groupBy`, then we would have been filtering on the average of **all `favNum` values across all entities**. By using, `groupBy` & `having`, we can filter on the average of only those values grouped to a particular `?name`.
+- [Aggregations & Grouping](../aggregations/) — Group and aggregate results
+- [Modifiers](../modifiers/) — Order, limit, and paginate results


### PR DESCRIPTION
## Summary

Restructures **Reference > Querying > FlureeQL** from single file to organized directory:

- **index.mdx**: Query structure overview
- **select-clauses.mdx**: Select syntax and patterns
- **where-clauses.mdx**: (refactored from flureeql-query-syntax.mdx) Where clause patterns
- **aggregations.mdx**: count, sum, avg, etc.
- **modifiers.mdx**: limit, offset, orderBy, groupBy
- **advanced-features.mdx**: Subqueries, unions, optional patterns

### Removed
- **flureeql-query-syntax.mdx**: Content split into directory structure

## Test plan

- [ ] Verify query examples return expected results
- [ ] Check all syntax variations are documented