### PR TITLE
docs: add feature reference docs

### DIFF
--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -1,0 +1,410 @@
+# Authentication
+
+This guide covers authentication options for Fluree Server and Fluree Cloud.
+
+---
+
+## Overview
+
+Fluree supports several authentication methods depending on your deployment:
+
+| Deployment | Authentication Method |
+|------------|----------------------|
+| **Fluree Server (open)** | No authentication required (default) |
+| **Fluree Server (closed)** | Root identities via `closedMode` config |
+| **Fluree Cloud** | API keys via `Authorization` header |
+| **Policy-based** | Identity headers for per-request policies |
+
+---
+
+## Fluree Server Authentication
+
+### Open Mode (Default)
+
+By default, Fluree Server runs in open mode with no authentication. All endpoints accept unauthenticated requests:
+
+```sh
+curl -X POST "http://localhost:8090/fluree/query" \
+  -H "Content-Type: application/json" \
+  -d '{"from": "my-ledger", "select": {"?s": ["*"]}, "where": {"@id": "?s"}}'
+```
+
+This is suitable for development and trusted internal networks.
+
+### Closed Mode
+
+For production environments, enable `closedMode` to require authentication:
+
+```yaml
+# fluree-config.edn
+{:fluree.server/closed-mode {:root-identities ["did:fluree:admin123"]}}
+```
+
+Or via environment variable:
+
+```sh
+export FLUREE_SERVER_CLOSED_MODE_ROOT_IDENTITIES='["did:fluree:admin123"]'
+```
+
+In closed mode, requests must include a valid identity. See [Server Configuration](/docs/reference/fluree-server-config#closed-mode) for details.
+
+---
+
+## Fluree Cloud Authentication
+
+Fluree Cloud requires API key authentication for all requests.
+
+### Generating an API Key
+
+1. Navigate to your dataset in Fluree Cloud
+2. Go to **Settings** > **API Keys**
+3. (Optional) Name your API key
+4. (Optional) Assign roles to limit permissions
+5. Click **Generate Key**
+6. Copy the key — it's only shown once
+
+> **NOTE**: If you don't assign a role, the API key has full read-write access.
+
+### Using API Keys
+
+Include the API key in the `Authorization` header:
+
+```sh
+curl -X POST "https://data.flur.ee/fluree/query" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: YOUR_API_KEY" \
+  -d '{
+    "from": "fluree-jld/387028092977716",
+    "select": {"?s": ["*"]},
+    "where": {"@id": "?s", "@type": "ex:Person"}
+  }'
+```
+
+### JavaScript Example
+
+```javascript
+const API_KEY = 'your-api-key-here';
+const DATASET_ID = 'fluree-jld/387028092977716';
+
+const response = await fetch('https://data.flur.ee/fluree/query', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': API_KEY
+  },
+  body: JSON.stringify({
+    from: DATASET_ID,
+    select: { '?s': ['*'] },
+    where: { '@id': '?s', '@type': 'ex:Person' }
+  })
+});
+
+const data = await response.json();
+console.log(data);
+```
+
+### Python Example
+
+```python
+import requests
+
+API_KEY = 'your-api-key-here'
+DATASET_ID = 'fluree-jld/387028092977716'
+
+response = requests.post(
+    'https://data.flur.ee/fluree/query',
+    headers={
+        'Content-Type': 'application/json',
+        'Authorization': API_KEY
+    },
+    json={
+        'from': DATASET_ID,
+        'select': {'?s': ['*']},
+        'where': {'@id': '?s', '@type': 'ex:Person'}
+    }
+)
+
+print(response.json())
+```
+
+---
+
+## Identity Headers
+
+For policy-based access control, use identity headers to specify who is making the request. This works with both self-hosted and cloud deployments.
+
+### Available Headers
+
+| Header | Description |
+|--------|-------------|
+| `fluree-identity` | User identity (DID or IRI) for policy evaluation |
+| `fluree-policy` | Inline policy document (JSON string) |
+| `fluree-policy-identity` | Identity for policy lookup |
+| `fluree-policy-class` | Policy class to apply |
+| `fluree-policy-values` | Values to bind in policy evaluation (JSON string) |
+
+### Example: Query as Specific User
+
+```sh
+curl -X POST "http://localhost:8090/fluree/query" \
+  -H "Content-Type: application/json" \
+  -H "fluree-identity: ex:alice" \
+  -d '{
+    "from": "my-ledger",
+    "select": {"?s": ["*"]},
+    "where": {"@id": "?s"}
+  }'
+```
+
+The query results will be filtered based on any policies defined for `ex:alice`.
+
+### Example: Apply Inline Policy
+
+```sh
+curl -X POST "http://localhost:8090/fluree/query" \
+  -H "Content-Type: application/json" \
+  -H 'fluree-policy: {"@id": "ex:readOnly", "f:targetClass": {"@id": "ex:Person"}, "f:allow": [{"@id": "f:view"}]}' \
+  -d '{
+    "from": "my-ledger",
+    "select": {"?s": ["*"]},
+    "where": {"@id": "?s"}
+  }'
+```
+
+For more on policies, see [Policy Syntax](/docs/reference/policy-syntax) and [Data Access Control](/docs/learn/security/data-access-control-concepts/).
+
+---
+
+## Verifiable Credentials (JWS)
+
+Fluree supports cryptographically signed requests using JSON Web Signatures (JWS). This provides:
+
+- **Authentication** — Verify who is making the request
+- **Integrity** — Ensure the request hasn't been tampered with
+- **Non-repudiation** — Cryptographic proof of the request origin
+
+### JWS Request Format
+
+Set the `Content-Type` header to `application/jwt` and send the signed JWS as the request body:
+
+```sh
+curl -X POST "http://localhost:8090/fluree/create" \
+  -H "Content-Type: application/jwt" \
+  -d 'eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19...'
+```
+
+The JWS payload contains the JSON query or transaction, signed with an Ed25519 private key.
+
+### DID (Decentralized Identifier)
+
+Fluree uses `did:key` format for identities. A DID is derived from your public key:
+
+```
+did:key:z6MkmbNqfM3ANYZnzDp9YDfa62pHggKosBkCyVdgQtgEKkGQ
+```
+
+### Creating Signed Requests
+
+Use the Fluree crypto library to sign requests:
+
+```javascript
+import { createJws } from '@fluree/crypto';
+
+const privateKey = 'your-ed25519-private-key-hex';
+
+const query = {
+  from: "my-ledger",
+  select: { "?s": ["*"] },
+  where: { "@id": "?s" }
+};
+
+const jws = createJws(JSON.stringify(query), privateKey, { includePubkey: true });
+```
+
+### Credential-Wrapped Operations
+
+When using the Fluree library directly, use the credential functions:
+
+**Signed Transaction:**
+```javascript
+import { credentialUpdate } from '@fluree/db';
+
+const signedTx = await credential.generate({
+  ledger: "my-ledger",
+  insert: { "@id": "ex:newEntity", "ex:name": "Test" }
+}, privateKey);
+
+await fluree.credentialUpdate(conn, signedTx);
+```
+
+**Signed Query:**
+```javascript
+import { credentialQuery } from '@fluree/db';
+
+const signedQuery = await credential.generate({
+  from: "my-ledger",
+  select: { "?s": ["*"] },
+  where: { "@id": "?s" }
+}, privateKey);
+
+const results = await fluree.credentialQuery(db, signedQuery);
+```
+
+**Signed History Query:**
+```javascript
+import { credentialHistory } from '@fluree/db';
+
+const signedHistory = await credential.generate({
+  history: "ex:entity",
+  t: { from: 1 }
+}, privateKey);
+
+const history = await fluree.credentialHistory(conn, "my-ledger", signedHistory);
+```
+
+---
+
+## Closed Mode (Server)
+
+Closed mode requires all requests to be cryptographically signed. This is essential for production deployments where you need strict access control.
+
+### Enabling Closed Mode
+
+Configure closed mode in your server configuration:
+
+```edn
+;; fluree-config.edn
+{:fluree.server/closed-mode
+ {:root-identities ["did:key:z6MkmbNqfM3ANYZnzDp9YDfa62pHggKosBkCyVdgQtgEKkGQ"]}}
+```
+
+Or via environment variable:
+
+```sh
+export FLUREE_SERVER_CLOSED_MODE_ROOT_IDENTITIES='["did:key:z6MkmbNqfM3ANYZnzDp9YDfa62pHggKosBkCyVdgQtgEKkGQ"]'
+```
+
+### Root vs Non-Root Identities
+
+| Action | Root Identity | Non-Root Identity |
+|--------|--------------|-------------------|
+| Create ledger | ✅ Allowed | ❌ Rejected (403) |
+| Drop ledger | ✅ Allowed | ❌ Rejected (403) |
+| Transact | ✅ Allowed | Subject to policies |
+| Query | ✅ Allowed | Subject to policies |
+| History | ✅ Allowed | Subject to policies |
+
+Root identities can perform administrative operations. Non-root identities can only access data permitted by policies.
+
+### Closed Mode Request Flow
+
+1. **Request arrives** — Server checks for JWS signature
+2. **Missing signature** → 400 "Missing credential"
+3. **Signature verified** → Extract DID from public key
+4. **DID checked** → Is it a root identity?
+5. **Root identity** → Full access to operation
+6. **Non-root identity** → Apply policies, filter results
+
+### Example: Closed Mode Requests
+
+**Create Ledger (Root Only):**
+```sh
+# Sign the request with a root identity's private key
+JWS=$(fluree-crypto sign '{
+  "ledger": "my-ledger",
+  "insert": {"@id": "ex:initial", "ex:name": "Initial Data"}
+}' $ROOT_PRIVATE_KEY)
+
+curl -X POST "http://localhost:8090/fluree/create" \
+  -H "Content-Type: application/jwt" \
+  -d "$JWS"
+```
+
+**Query (Any Signed Request):**
+```sh
+JWS=$(fluree-crypto sign '{
+  "from": "my-ledger",
+  "select": {"?s": ["*"]},
+  "where": {"@id": "?s"}
+}' $USER_PRIVATE_KEY)
+
+curl -X POST "http://localhost:8090/fluree/query" \
+  -H "Content-Type: application/jwt" \
+  -d "$JWS"
+```
+
+### Setting Up Policies for Non-Root Users
+
+For non-root identities to access data, define policies in your ledger:
+
+```json
+{
+  "insert": [
+    {
+      "@id": "ex:userPolicy",
+      "@type": ["f:AccessPolicy", "ex:DefaultUserPolicy"],
+      "f:action": [{"@id": "f:view"}, {"@id": "f:modify"}],
+      "f:query": {
+        "@type": "@json",
+        "@value": {
+          "where": [["filter", "(= ?$this ?$identity)"]]
+        }
+      }
+    },
+    {
+      "@id": "did:key:z6MkiKJFxJJd9QuqKgzBR2kiSybE9V2517sFd2kTS7kQe9mg",
+      "f:policyClass": {"@id": "ex:DefaultUserPolicy"},
+      "@type": "ex:User",
+      "ex:name": "Alice"
+    }
+  ]
+}
+```
+
+This policy allows users to view and modify only their own data (where `?$this` equals `?$identity`).
+
+### Security Considerations
+
+1. **Protect private keys** — Never expose private keys; use secure key management
+2. **Use unique identities** — Each user/service should have its own key pair
+3. **Audit root access** — Limit and monitor root identity usage
+4. **Rotate keys** — Periodically rotate key pairs for compromised key recovery
+
+---
+
+## Resource Control
+
+These headers help control and monitor request resource usage:
+
+| Header | Description |
+|--------|-------------|
+| `fluree-max-fuel` | Maximum computational units allowed |
+| `fluree-track-fuel` | Include fuel consumption in response |
+| `fluree-track-meta` | Include metadata in response |
+| `fluree-track-policy` | Include policy evaluation details |
+
+### Example: Track Fuel Usage
+
+```sh
+curl -X POST "http://localhost:8090/fluree/query" \
+  -H "Content-Type: application/json" \
+  -H "fluree-max-fuel: 10000" \
+  -H "fluree-track-fuel: true" \
+  -d '{
+    "from": "my-ledger",
+    "select": {"?s": ["*"]},
+    "where": {"@id": "?s"}
+  }'
+```
+
+The response will include fuel consumption in the `x-fdb-fuel` header.
+
+---
+
+## Best Practices
+
+1. **Never commit API keys** — Use environment variables or secret management
+2. **Use least privilege** — Assign roles to API keys that limit access
+3. **Rotate keys regularly** — Generate new keys and revoke old ones periodically
+4. **Use HTTPS** — Always use encrypted connections in production
+5. **Monitor usage** — Track fuel consumption to detect anomalies

--- a/docs/reference/cloud-http-api.md
+++ b/docs/reference/cloud-http-api.md
@@ -232,7 +232,7 @@ Commit a transaction to a ledger.
 
 | Key        | Required | Value                                                                                                                       |
 | ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `@context` | no       | **object** • a map of terms for the transaction ([See our Guide on Using Context](/docs/learn/guides/working-with-context)) |
+| `@context` | no       | **object** • a map of terms for the transaction ([See our Guide on Using Context](/docs/learn/working-with-data/context-patterns/)) |
 | `ledger`   | yes      | **string** • the name of the _existing_ ledger                                                                              |
 | `insert`   | no       | **object** or **array** • data to be asserted                                                                               |
 | `where`    | no       | **object** or **array** • a subquery to bind logic variables for use in your `delete` and/or `insert` clauses               |
@@ -296,13 +296,13 @@ POST /fluree/query
 
 | Key        | Required | Value                                                                                                                                                                                                          |
 | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@context` | no       | **object** • a map of terms for the query and the result set ([See our Guide on Using Context](/docs/learn/guides/working-with-context))                                                                       |
+| `@context` | no       | **object** • a map of terms for the query and the result set ([See our Guide on Using Context](/docs/learn/working-with-data/context-patterns/))                                                                       |
 | `from`     | yes      | **string** • the name of the _existing_ ledger                                                                                                                                                                 |
-| `where`    | no       | **object** or **array** • a subquery to set query constraints and bind logic variables for use in your `select` clause [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/flureeql-query-syntax) |
-| `select`   | yes      | **object** or **array** • a clause used to format the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/flureeql-query-syntax)                               |
-| `groupBy`  | no       | **string** • an optional clause used to group the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/flureeql-query-syntax)                                   |
+| `where`    | no       | **object** or **array** • a subquery to set query constraints and bind logic variables for use in your `select` clause [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/querying/) |
+| `select`   | yes      | **object** or **array** • a clause used to format the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/querying/)                               |
+| `groupBy`  | no       | **string** • an optional clause used to group the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/querying/)                                   |
 | `having`   | no       | **string** or **array** • an optional clause used to filter the projected result set of your query (requires the use of `groupBy`)                                                                             |
-| `orderBy`  | no       | **string** • an optional clause used to order the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/flureeql-query-syntax)                                   |
+| `orderBy`  | no       | **string** • an optional clause used to order the projected result set of your query [See our Reference Doc on FlureeQL Query Syntax](/docs/reference/querying/)                                   |
 | `opts`     | no       | **object** • an optional object used to set query options, such as the `role` or `did` identity of the querying entity                                                                                         |
 
 ### Example Request Object
@@ -391,7 +391,7 @@ POST /fluree/history
 
 | Key              | Required | Value                                                                                                                                                                                                                 |
 | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@context`       | no       | **object** • a map of terms for the history query and the result set ([See our Guide on Using Context](/docs/learn/guides/working-with-context))                                                                      |
+| `@context`       | no       | **object** • a map of terms for the history query and the result set ([See our Guide on Using Context](/docs/learn/working-with-data/context-patterns/))                                                                      |
 | `from`           | yes      | **string** • the name of the _existing_ ledger                                                                                                                                                                        |
 | `history`        | yes      | **string** or **array** • used to express the entity or entity patterns for which you are auditing history ([See the Reference section for Constraining Nodes](/docs/reference/history-syntax/#constraints-on-nodes)) |
 | `t`              | yes      | **object** • used to express individual commit/time values or ranges of commit/time values ([See the Reference section for Constraining by Time](/docs/reference/history-syntax/#constraints-on-time))                |

--- a/docs/reference/error-codes.mdx
+++ b/docs/reference/error-codes.mdx
@@ -1,41 +1,668 @@
 # Error Codes
 
-## query-missing-select
+This reference documents all error codes returned by Fluree. Errors include an error code keyword (e.g., `:db/invalid-query`), an HTTP status code, and a human-readable message.
 
-This error is caused by a missing `select` key, which is required for all FlureeQL queries. You can find out more information on required keys in [FlureeQL syntax](/docs/reference/flureeql-query-syntax/#query-object)
+## Error Response Format
 
-## query-missing-where
+Fluree returns errors in this structure:
 
-This error is caused by a missing `where` key, which is required for all FlureeQL queries. You can find out more information on required keys in [FlureeQL syntax](/docs/reference/flureeql-query-syntax/#query-object)
+```json
+{
+  "status": 400,
+  "error": ":db/invalid-query",
+  "message": "Human-readable description of the error"
+}
+```
 
-## query-unknown-key
+Some errors include additional context fields like `ledger`, `commit`, or validation reports.
 
-This error is caused by an invalid or unknown key in your query. Try checking for spelling errors and confirm that each key in your query is one of the following listed in our docs on the [Query Object](/docs/reference/flureeql-query-syntax/#query-object)
+---
 
-## query-invalid-history
+## Query Errors
 
-This error is caused by an invalid value is assigned to a history key in your query. You can look at our documentation on [history queries](/docs/reference/history-syntax/) here to ensure you are assigning an allowed data type that is properly formatted.
+Errors related to FlureeQL and SPARQL query syntax.
 
-## query-invalid-commit-details
+### `:db/invalid-query`
 
-The most common reason for invalid-commit-details errors is that a value other than a `boolean` (`true`/`false`) was assigned to this key, which acts as a flag to either include or exclude details about commits in a history query. You can also refer to our documentation on [History syntax](/docs/reference/history-syntax/#including-commit-details) to confirm your query is formatted properly.
+**Status:** 400
 
-## query-invalid-t
+Query syntax is invalid or malformed. This is a general query error that may have more specific variants below.
 
-This error is caused by an invalid value of `t` in your query. Check to be certain that the value for `t` is not out of range for your ledger and that it contains proper typing as explained [here](/docs/reference/flureeql-query-syntax/#t).
+### `query-missing-select`
 
-## query-invalid-select
+**Status:** 400
 
-This error is typically caused by an incorrect usage of the `select` key. Check out our [FlureeQL query syntax documentation](/docs/reference/flureeql-query-syntax/#select) on the `select` key to confirm you are using the proper options, syntax, and formatting.
+Missing `select` key, which is required for all FlureeQL queries. See [FlureeQL syntax](/docs/reference/querying/#query-object).
 
-## query-invalid-where
+### `query-missing-where`
 
-This error is typically caused by an incorrect usage of the `where` key. Check out our [FlureeQL query syntax documentation](/docs/reference/flureeql-query-syntax/#where) on the `where` key to confirm you are using the proper options, syntax, and formatting.
+**Status:** 400
 
-## query-invalid-orderby
+Missing `where` key, which is required for all FlureeQL queries. See [FlureeQL syntax](/docs/reference/querying/#query-object).
 
-Typically this error is caused by an invalid value for the `orderBy` key. Use of `orderBy` requires a value `?binding` generated from the `where` clause. For example, if your `where` clause includes a binding for values on `?age` (e.g. `"schema:age": "?age"`), then you could order all query results according to ascending sorted order for `?age` like so: `"orderBy": "?age"`
+### `query-unknown-key`
 
-## query-invalid-groupby
+**Status:** 400
 
-This error is typically caused by an invalid value for the `groupBy` key that is neither recognized as a valid variable or vector of variables. `groupBy` must be assigned to either an array or a string. For more information and reference on this key, check out our documentation on `groupBy` [here](/docs/reference/flureeql-query-syntax/#groupby).
+Invalid or unknown key in your query. Check for spelling errors and confirm each key is valid per the [Query Object](/docs/reference/querying/#query-object) documentation.
+
+### `query-invalid-select`
+
+**Status:** 400
+
+Incorrect usage of the `select` key. See [select syntax](/docs/reference/querying/select-clauses/).
+
+### `query-invalid-where`
+
+**Status:** 400
+
+Incorrect usage of the `where` key. See [where syntax](/docs/reference/querying/where-clauses/).
+
+### `query-invalid-orderby`
+
+**Status:** 400
+
+Invalid value for `orderBy`. Must reference a binding variable from the `where` clause (e.g., `"orderBy": "?age"`).
+
+### `query-invalid-groupby`
+
+**Status:** 400
+
+Invalid value for `groupBy`. Must be a string or array of binding variables. See [groupBy](/docs/reference/querying/aggregations/#groupby).
+
+### `query-invalid-t`
+
+**Status:** 400
+
+Invalid `t` (transaction) value. Ensure the value is within range for your ledger and properly typed. See [t parameter](/docs/reference/querying/modifiers/#t).
+
+### `:db/invalid-property-path`
+
+**Status:** 400
+
+Property path expression in query is malformed or unsupported.
+
+### `:db/invalid-predicate`
+
+**Status:** 400
+
+Predicate IRI in query is invalid or not found.
+
+### `:db/unsupported-transitive-path`
+
+**Status:** 400
+
+Transitive path syntax used is not supported.
+
+---
+
+## History Query Errors
+
+Errors specific to history queries.
+
+### `query-invalid-history`
+
+**Status:** 400
+
+Invalid value assigned to the `history` key. See [history queries](/docs/reference/history-syntax/).
+
+### `query-invalid-commit-details`
+
+**Status:** 400
+
+The `commit-details` key requires a boolean (`true`/`false`). See [commit details](/docs/reference/history-syntax/#including-commit-details).
+
+---
+
+## Transaction Errors
+
+Errors when creating, updating, or deleting data.
+
+### `:db/invalid-transaction`
+
+**Status:** 400
+
+Transaction format is malformed or contains invalid syntax.
+
+### `:db/invalid-txn`
+
+**Status:** 400
+
+Transaction parsing failed. Check JSON structure and required fields.
+
+### `:db/invalid-update`
+
+**Status:** 400
+
+Update operation is invalid. Verify the update syntax and target entities exist.
+
+### `:db/invalid-retraction`
+
+**Status:** 400
+
+Retraction in transaction is invalid. Ensure you're retracting existing data with correct syntax.
+
+### `:db/invalid-annotation`
+
+**Status:** 400
+
+Commit annotation is malformed. Annotations must be valid JSON-LD.
+
+---
+
+## Data Validation Errors
+
+Errors when data doesn't match expected types or constraints.
+
+### `:db/invalid-value`
+
+**Status:** 400
+
+Value cannot be coerced to the specified datatype. Check that the value matches the property's expected type.
+
+### `:db/value-coercion`
+
+**Status:** 400
+
+Automatic value coercion failed. The provided value is incompatible with the target datatype.
+
+### `:db/invalid-datatype`
+
+**Status:** 400
+
+Unsupported or unrecognized datatype specified.
+
+### `:db/invalid-time`
+
+**Status:** 400
+
+Time value is not ISO-8601 compliant. Use format like `"2024-01-15T10:30:00Z"`.
+
+### `:db/invalid-json`
+
+**Status:** 400
+
+JSON parsing or validation failed. Check for syntax errors in your JSON payload.
+
+### `:db/invalid-dense-vector`
+
+**Status:** 400
+
+Dense vector has invalid structure. Vectors must be arrays of numbers with consistent dimensions.
+
+---
+
+## SHACL Validation Errors
+
+Errors when data violates SHACL shape constraints.
+
+### `:shacl/violation`
+
+**Status:** 422
+
+Data violates one or more SHACL constraints. The response includes a detailed validation report:
+
+```json
+{
+  "status": 422,
+  "error": ":shacl/violation",
+  "message": "SHACL validation failed",
+  "report": {
+    "constraint": "sh:minCount",
+    "focusNode": "ex:Person1",
+    "path": "schema:name",
+    "value": null,
+    "expectedValue": 1
+  }
+}
+```
+
+See [SHACL validation](/docs/reference/shacl-validation) for constraint details.
+
+---
+
+## Ledger Errors
+
+Errors related to ledger creation and management.
+
+### `:db/ledger-exists`
+
+**Status:** 409
+
+Cannot create ledger because one with this name already exists.
+
+### `:db/ledger-not-exists`
+
+**Status:** 409
+
+Specified ledger does not exist. Check the ledger name and ensure it has been created.
+
+### `:db/invalid-ledger-name`
+
+**Status:** 400
+
+Ledger name contains invalid characters or format. Names should be alphanumeric with hyphens/underscores.
+
+### `:db/invalid-ledger-id`
+
+**Status:** 400
+
+Ledger ID is invalid or missing from request.
+
+### `:db/invalid-ledger-opts`
+
+**Status:** 400
+
+Invalid options provided during ledger creation.
+
+### `:db/unkown-ledger`
+
+**Status:** 400
+
+Referenced ledger is unknown or not accessible.
+
+---
+
+## Branch Errors
+
+Errors related to ledger branches.
+
+### `:db/invalid-branch-name`
+
+**Status:** 400
+
+Branch name contains invalid characters or format.
+
+### `:db/invalid-branch`
+
+**Status:** 400
+
+Specified branch does not exist on this ledger.
+
+---
+
+## Commit & Time Travel Errors
+
+Errors when working with commits and time travel queries.
+
+### `:db/invalid-commit`
+
+**Status:** 400
+
+Commit structure is malformed or missing required fields.
+
+### `:db/invalid-commit-sha`
+
+**Status:** 400
+
+Commit SHA prefix or format is invalid.
+
+### `:db/ambiguous-commit-sha`
+
+**Status:** 400
+
+SHA prefix matches multiple commits. Provide a longer, more specific prefix.
+
+### `:db/commit-not-found`
+
+**Status:** 404
+
+Specified commit was not found in the ledger history.
+
+### `:db/invalid-time-travel`
+
+**Status:** 400
+
+Time travel specification is invalid. Check the `t`, `at`, or commit reference.
+
+### `:db/missing-transaction`
+
+**Status:** 404
+
+Transaction not found for the specified address.
+
+---
+
+## Policy & Authorization Errors
+
+Errors related to data access policies.
+
+### `:db/policy-exception`
+
+**Status:** 403
+
+Policy rule enforcement failed. The current identity doesn't have permission for this operation.
+
+### `:db/policy-error`
+
+**Status:** 400
+
+Policy definition parsing or validation failed. Check your policy syntax.
+
+---
+
+## Credential & Authentication Errors
+
+Errors related to verifiable credentials and signatures.
+
+### `:db/invalid-credential`
+
+**Status:** 400
+
+Credential verification failed. The credential may be malformed, expired, or have an invalid signature.
+
+### `:db/missing-credentials`
+
+**Status:** 400
+
+Authentication credentials not provided. Include a signed credential with your request.
+
+### `:credential/invalid-signature`
+
+**Status:** 400
+
+Cryptographic signature verification failed. The signature doesn't match the credential content.
+
+### `:credential/unknown-signing-algorithm`
+
+**Status:** 400
+
+JWS header contains an unsupported signing algorithm. Supported algorithms include ES256K.
+
+---
+
+## Configuration Errors
+
+Errors related to Fluree configuration.
+
+### `:db/invalid-config`
+
+**Status:** 400
+
+Configuration structure is invalid.
+
+### `:db/invalid-config-json`
+
+**Status:** 400
+
+Configuration JSON parsing failed.
+
+### `:db/invalid-configuration`
+
+**Status:** 400
+
+Configuration validation failed. Check required fields and value types.
+
+### `:db/missing-config-val`
+
+**Status:** 400
+
+Required configuration value is missing.
+
+### `:db/unsupported-config`
+
+**Status:** 400
+
+Configuration option is not supported in this version.
+
+### `:server/missing-config`
+
+**Status:** 400
+
+Server configuration file or resource not found.
+
+---
+
+## Connection Errors
+
+Errors related to database connections.
+
+### `:db/invalid-connection`
+
+**Status:** 400
+
+Connection object is invalid or has been closed.
+
+### `:db/connection-error`
+
+**Status:** 500
+
+Failed to establish database connection.
+
+### `:db/invalid-address`
+
+**Status:** 400
+
+Ledger address format is invalid.
+
+### `:db/invalid-server-address`
+
+**Status:** 400
+
+Server address format is invalid. Check the host and port.
+
+---
+
+## Storage Errors
+
+Errors related to data storage operations.
+
+### `:db/storage-error`
+
+**Status:** 500
+
+Underlying storage system error. This may indicate disk issues, permissions problems, or encryption failures.
+
+### `:db/file-unavailable`
+
+**Status:** 400
+
+Required file cannot be accessed. Check file permissions and path.
+
+---
+
+## IPFS & Nameservice Errors
+
+Errors when using IPFS or nameservice features.
+
+### `:db/ipfs-failure`
+
+**Status:** 500
+
+IPFS operation failed. Check IPFS daemon connectivity.
+
+### `:db/ipns`
+
+**Status:** 500
+
+IPNS resolution error.
+
+### `:db/push-ipfs`
+
+**Status:** 500
+
+Failed to push data to IPFS.
+
+### `:db/missing-ipns-key`
+
+**Status:** 400
+
+IPNS key not configured. Set up an IPNS key before publishing.
+
+### `:db/no-nameservice`
+
+**Status:** 400
+
+No nameservice available for this operation.
+
+---
+
+## Server & Consensus Errors
+
+Errors from the Fluree server layer (when running fluree/server).
+
+### `:server/invalid-header`
+
+**Status:** 400
+
+Invalid HTTP header format. Boolean or JSON headers may be malformed.
+
+### `:server/unrecognized-transaction`
+
+**Status:** 400
+
+Transaction format not recognized by the server.
+
+### `:consensus/not-leader`
+
+**Status:** 400
+
+Server is not the current leader in a Raft cluster. Retry the request or redirect to the leader.
+
+### `:consensus/response-timeout`
+
+**Status:** 408
+
+Timeout waiting for consensus response. The cluster may be experiencing network issues.
+
+### `:consensus/no-response`
+
+**Status:** 500
+
+Missing event result from consensus layer.
+
+### `:consensus/unexpected-event`
+
+**Status:** 500
+
+Unrecognized consensus event type received.
+
+### `:consensus/config`
+
+**Status:** 500
+
+Configuration error in consensus setup.
+
+### `:db/leader-timeout`
+
+**Status:** 400
+
+Leader election timed out. The cluster may not have quorum.
+
+---
+
+## Capacity & Rate Limiting Errors
+
+Errors when system resources are constrained.
+
+### `:db/queue-full`
+
+**Status:** 429
+
+Transaction queue is full. The server is under heavy load; retry after a delay.
+
+### `:db/pending-transaction-limit`
+
+**Status:** 503
+
+Too many pending transactions. Wait for current transactions to complete.
+
+### `:db/max-novelty-exceeded`
+
+**Status:** 503
+
+Novelty index exceeded maximum size. Reindexing is required before accepting new transactions.
+
+### `:db/unavailable`
+
+**Status:** 503
+
+Service temporarily unavailable. The server may be starting up or performing maintenance.
+
+---
+
+## Index Errors
+
+Errors related to database indexing.
+
+### `:db/indexing`
+
+**Status:** 503
+
+Indexing operation is in progress. Retry after indexing completes.
+
+### `:db/index-invariant-failure`
+
+**Status:** 500
+
+Index tree structure invariant violated. This indicates a potential data integrity issue.
+
+### `:db/invalid-index`
+
+**Status:** 400
+
+Invalid index specification.
+
+---
+
+## System Errors
+
+General system-level errors.
+
+### `:db/unexpected-error`
+
+**Status:** 500
+
+An unexpected error occurred. Check server logs for details.
+
+### `:db/optimization-failure`
+
+**Status:** 500
+
+Query optimization failed. Try simplifying the query.
+
+### `:db/timeout`
+
+**Status:** 408
+
+Operation exceeded time limit.
+
+### `:db/system`
+
+**Status:** 500
+
+System-level error. Check server logs.
+
+### `:db/migration`
+
+**Status:** 500
+
+Error during data migration or upgrade.
+
+### `:node/consensus`
+
+**Status:** 500
+
+Unexpected exception in consensus event handler.
+
+### `:db/websocket-error`
+
+**Status:** 500
+
+WebSocket communication error.
+
+---
+
+## HTTP Status Code Reference
+
+| Status | Meaning | Common Causes |
+|--------|---------|---------------|
+| 400 | Bad Request | Invalid syntax, missing required fields, malformed data |
+| 403 | Forbidden | Policy violation, insufficient permissions |
+| 404 | Not Found | Missing ledger, commit, or transaction |
+| 408 | Timeout | Operation took too long, consensus timeout |
+| 409 | Conflict | Ledger already exists, concurrent modification |
+| 422 | Unprocessable Entity | SHACL validation failure |
+| 429 | Too Many Requests | Rate limiting, queue full |
+| 500 | Internal Server Error | Unexpected errors, system issues |
+| 503 | Service Unavailable | Server overloaded, indexing in progress |

--- a/docs/reference/full-text-search.mdx
+++ b/docs/reference/full-text-search.mdx
@@ -1,0 +1,255 @@
+# Full-Text Search (BM25)
+
+<div class="overview">
+  Fluree supports full-text search using the BM25 algorithm through virtual graphs. This enables powerful text search capabilities including stemming, stopword removal, and relevance scoring.
+</div>
+
+---
+
+## Overview
+
+BM25 (Best Match 25) is a ranking function used by search engines to estimate the relevance of documents to a search query. Fluree implements BM25 through virtual graphs, which are computed indexes that stay synchronized with your data.
+
+Key features:
+- **Automatic indexing** — Data matching your query is automatically indexed
+- **Relevance scoring** — Results ranked by BM25 score
+- **Stemming** — Words reduced to root form (e.g., "running" → "run")
+- **Stopwords** — Common words filtered out (e.g., "the", "and")
+- **Incremental updates** — Index updates automatically as data changes
+
+## Creating a BM25 Index
+
+Define a BM25 index by inserting an entity with types `f:VirtualGraph` and `fidx:BM25`:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "fidx": "https://ns.flur.ee/index#",
+    "ex": "http://example.org/"
+  },
+  "insert": {
+    "@id": "ex:articleSearch",
+    "@type": ["f:VirtualGraph", "fidx:BM25"],
+    "f:virtualGraph": "articleSearch",
+    "fidx:stemmer": {"@id": "fidx:snowballStemmer-en"},
+    "fidx:stopwords": {"@id": "fidx:stopwords-en"},
+    "f:query": {
+      "@type": "@json",
+      "@value": {
+        "@context": {"ex": "http://example.org/"},
+        "where": [{"@id": "?x", "ex:author": "?author"}],
+        "select": {"?x": ["@id", "ex:title", "ex:summary"]}
+      }
+    }
+  }
+}
+```
+
+### Required Properties
+
+| Property | Description |
+|----------|-------------|
+| `@type` | Must include both `f:VirtualGraph` and `fidx:BM25` |
+| `f:virtualGraph` | Name used to reference the index in queries |
+| `f:query` | Query defining which data to index |
+
+### Configuration Options
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `fidx:stemmer` | Stemmer algorithm for the index | None |
+| `fidx:stopwords` | Stopwords list to filter common words | None |
+
+### Available Stemmers
+
+| Stemmer ID | Language |
+|------------|----------|
+| `fidx:snowballStemmer-en` | English |
+
+### Available Stopword Lists
+
+| Stopwords ID | Language |
+|--------------|----------|
+| `fidx:stopwords-en` | English |
+
+### Index Query Requirements
+
+The `f:query` property defines what data gets indexed. It has specific requirements:
+
+1. **Must use subgraph selector** — The `select` must be an object, not an array
+2. **Must include `@id`** — The subgraph selector must include `"@id"`
+3. **Cannot use wildcard** — Cannot use `"*"` in the selector
+
+**Valid:**
+```json
+{"select": {"?x": ["@id", "ex:title", "ex:summary"]}}
+```
+
+**Invalid:**
+```json
+{"select": ["?x", "?title"]}  // Not a subgraph selector
+{"select": {"?x": ["ex:title"]}}  // Missing @id
+{"select": {"?x": ["@id", "*"]}}  // Contains wildcard
+```
+
+## Querying a BM25 Index
+
+Query the index using a `graph` clause with the index name prefixed by `##`:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "fidx": "https://ns.flur.ee/index#"
+  },
+  "select": ["?doc", "?score", "?title"],
+  "where": [
+    ["graph", "##articleSearch", {
+      "fidx:target": "search terms here",
+      "fidx:limit": 10,
+      "fidx:result": {
+        "@id": "?doc",
+        "fidx:score": "?score"
+      }
+    }],
+    {"@id": "?doc", "ex:title": "?title"}
+  ]
+}
+```
+
+### Query Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `fidx:target` | Yes | Search query string |
+| `fidx:limit` | No | Maximum number of results |
+| `fidx:sync` | No | Wait for index to be current (default: false) |
+| `fidx:result` | Yes | Result binding pattern |
+
+### Result Binding
+
+The `fidx:result` object binds variables to the search results:
+
+```json
+{
+  "fidx:result": {
+    "@id": "?doc",
+    "fidx:score": "?score"
+  }
+}
+```
+
+- `@id` binds the IRI of matching documents
+- `fidx:score` binds the BM25 relevance score
+
+## Complete Example
+
+### 1. Insert Data
+
+```json
+{
+  "@context": {"ex": "http://example.org/"},
+  "insert": [
+    {
+      "@id": "ex:article1",
+      "ex:author": "Jane Smith",
+      "ex:title": "Introduction to Graph Databases",
+      "ex:summary": "Graph databases store data as nodes and edges, enabling complex relationship queries."
+    },
+    {
+      "@id": "ex:article2",
+      "ex:author": "John Doe",
+      "ex:title": "Semantic Web Technologies",
+      "ex:summary": "The semantic web uses RDF and linked data to create machine-readable content."
+    },
+    {
+      "@id": "ex:article3",
+      "ex:author": "Jane Smith",
+      "ex:title": "Building Knowledge Graphs",
+      "ex:summary": "Knowledge graphs combine structured data with semantic relationships for AI applications."
+    }
+  ]
+}
+```
+
+### 2. Create Index
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "fidx": "https://ns.flur.ee/index#",
+    "ex": "http://example.org/"
+  },
+  "insert": {
+    "@id": "ex:articleIndex",
+    "@type": ["f:VirtualGraph", "fidx:BM25"],
+    "f:virtualGraph": "articleIndex",
+    "fidx:stemmer": {"@id": "fidx:snowballStemmer-en"},
+    "fidx:stopwords": {"@id": "fidx:stopwords-en"},
+    "f:query": {
+      "@type": "@json",
+      "@value": {
+        "@context": {"ex": "http://example.org/"},
+        "where": [{"@id": "?x", "ex:author": "?author"}],
+        "select": {"?x": ["@id", "ex:title", "ex:summary"]}
+      }
+    }
+  }
+}
+```
+
+### 3. Search the Index
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "fidx": "https://ns.flur.ee/index#"
+  },
+  "select": ["?doc", "?score", "?title"],
+  "where": [
+    ["graph", "##articleIndex", {
+      "fidx:target": "semantic knowledge graph",
+      "fidx:limit": 10,
+      "fidx:result": {
+        "@id": "?doc",
+        "fidx:score": "?score"
+      }
+    }],
+    {"@id": "?doc", "ex:title": "?title"}
+  ],
+  "orderBy": "(desc ?score)"
+}
+```
+
+This returns articles ranked by relevance to "semantic knowledge graph", with stemming applied (e.g., "graph" matches "graphs").
+
+## How BM25 Scoring Works
+
+BM25 scores documents based on:
+
+1. **Term frequency (TF)** — How often search terms appear in a document
+2. **Inverse document frequency (IDF)** — How rare the terms are across all documents
+3. **Document length normalization** — Adjusts for document size
+
+Higher scores indicate more relevant documents. Scores are unbounded but typically range from 0 to several units depending on query and corpus.
+
+## Index Updates
+
+BM25 indexes update automatically when data changes:
+
+- **Inserts** — New documents matching the index query are added
+- **Updates** — Modified documents are re-indexed
+- **Deletes** — Removed documents are removed from the index
+
+Updates happen asynchronously. Use `fidx:sync: true` in queries if you need to ensure the index is current.
+
+## Best Practices
+
+1. **Be specific with index queries** — Index only the data you need to search
+2. **Use appropriate language settings** — Match stemmer and stopwords to your content language
+3. **Include all searchable fields** — The index only searches fields in the `select` subgraph
+4. **Use `fidx:limit`** — Limit results for better performance on large datasets
+5. **Order by score** — Use `orderBy: "(desc ?score)"` to show most relevant results first

--- a/docs/reference/policy-syntax.mdx
+++ b/docs/reference/policy-syntax.mdx
@@ -18,7 +18,7 @@ A Policy is used to decide which flakes can be viewed or modified. Here is the F
 
 | key                               | required? | type                      | example values|
 | --------------------------------- | --------- | ------------------------- | ----------------------------|
-| `f:query`                         | yes       | `WhereClause`             | `{"type": "@json", "@value": {"where": [["filter" "(= ?$this ?$identity)"]]}}` |
+| `f:query`                         | yes       | `WhereClause`             | `{"type": "@json", "@value": {"where": ["filter", "(= ?$this ?$identity)"]}}` |
 | `@context`                        | no        | `{[key: string]:TermDef}` | `{"f": "https://ns.flur.ee/"}`|
 | `@id`                             | no        | `IRI[]`                   | `"ex:MyPolicy"`|
 | `@type`                           | no        | `IRI[]`                   | `"ex:AdminPolicy"` |
@@ -71,11 +71,506 @@ Policies are processed for each flake that will be returned in this way:
 1. All `f:required` policies must evaluate to `true` to permit access the flake. Non required policies are ignored.
 2. If no policies are "required", then all the policies are checked in sequence. The first one to evaluate to `true` permits access. If no policy evaluates to true, access to the flake is denied.
 
-During policy evaluation, the `f:query` of each targeted policy is evaluated with certain variables bound:  
-`?$this` - the subject of the flake being tested  
-`?$identity` - the identity of the principal performing the action
+During policy evaluation, the `f:query` of each targeted policy is evaluated with certain variables bound (see [Policy Variables Reference](#policy-variables-reference) below).
 
 The query returns an authorization result:
 - 1+ results: flake is allowed
 - 0 results: flake is not allowed
 - error: operation is aborted
+
+## Policy Variables Reference
+
+Policy queries have access to special variables prefixed with `?$`. These are automatically bound during policy evaluation:
+
+| Variable | Description | Available In |
+|----------|-------------|--------------|
+| `?$this` | The subject (entity ID) of the flake being evaluated | All policies |
+| `?$identity` | The identity (DID or IRI) of the user making the request | All policies |
+| `?$target` | Bound by `f:targetSubject` or `f:targetProperty` where clauses | Targeting queries |
+| `?$property` | The property of the flake being evaluated | Property-targeted policies |
+
+### Using Policy Variables
+
+**`?$this`** — The entity being accessed:
+```json
+{
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "where": [
+        { "@id": "?$this", "ex:owner": "?owner" },
+        ["filter", "(= ?owner ?$identity)"]
+      ]
+    }
+  }
+}
+```
+
+**`?$identity`** — The authenticated user:
+```json
+{
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "where": [
+        { "@id": "?$identity", "ex:role": "admin" }
+      ]
+    }
+  }
+}
+```
+
+**`?$target`** — Used in targeting where clauses:
+```json
+{
+  "f:targetSubject": {
+    "@type": "@json",
+    "@value": {
+      "where": [{ "@id": "?$target", "@type": "ex:ConfidentialDocument" }]
+    }
+  }
+}
+```
+
+### Custom Policy Values
+
+In addition to built-in variables, you can pass custom values via the `policy-values` option or `fluree-policy-values` header. Reference them with the `?$` prefix:
+
+```json
+{
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "where": [
+        { "@id": "?$this", "ex:department": "?dept" },
+        ["filter", "(= ?dept ?$department)"]
+      ]
+    }
+  }
+}
+```
+
+Pass the value at query time:
+```json
+{
+  "opts": {
+    "identity": "ex:alice",
+    "policy-values": { "department": "engineering" }
+  }
+}
+```
+
+## Policy Examples
+
+### Example 1: Read-Only Policy for Own Data
+
+This policy allows users to view only their own data:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:readOwnDataPolicy",
+  "f:action": { "@id": "f:view" },
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": [
+        ["filter", "(= ?$this ?$identity)"]
+      ]
+    }
+  }
+}
+```
+
+### Example 2: Role-Based Access Control
+
+This policy allows users with an admin role to view all data:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:adminViewPolicy",
+  "f:action": { "@id": "f:view" },
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": [
+        { "@id": "?$identity", "ex:role": "admin" }
+      ]
+    }
+  }
+}
+```
+
+### Example 3: Property-Level Protection
+
+This policy restricts access to sensitive properties:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:sensitivePropertyPolicy",
+  "f:targetProperty": [
+    { "@id": "ex:ssn" },
+    { "@id": "ex:salary" }
+  ],
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": [
+        { "@id": "?$identity", "ex:role": "hr" }
+      ]
+    }
+  }
+}
+```
+
+### Example 4: Write Protection
+
+This policy restricts who can modify data:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:writeProtectionPolicy",
+  "f:action": { "@id": "f:modify" },
+  "f:required": true,
+  "f:exMessage": "Only data owners can modify their records",
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": [
+        { "@id": "?$this", "ex:owner": "?owner" },
+        ["filter", "(= ?owner ?$identity)"]
+      ]
+    }
+  }
+}
+```
+
+## Using Policies with the HTTP API
+
+### Query-Level Policy via Request Body
+
+Include the `opts` object with identity information in your query:
+
+```json
+{
+  "from": "my-ledger",
+  "select": { "?s": ["*"] },
+  "where": { "@id": "?s", "@type": "ex:Person" },
+  "opts": {
+    "identity": "did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL"
+  }
+}
+```
+
+### Header-Based Policy
+
+Policies can be applied via HTTP headers:
+
+#### Identity Header
+
+```sh
+curl --location 'http://localhost:58090/fluree/query' \
+  --header 'Content-Type: application/json' \
+  --header 'fluree-identity: did:key:z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL' \
+  --data '{
+    "from": "my-ledger",
+    "select": { "?s": ["*"] },
+    "where": { "@id": "?s", "@type": "ex:Person" }
+  }'
+```
+
+#### Inline Policy Header
+
+For ad-hoc policy evaluation, use the `fluree-policy` header with a JSON policy document:
+
+```sh
+curl --location 'http://localhost:58090/fluree/query' \
+  --header 'Content-Type: application/json' \
+  --header 'fluree-identity: ex:alice' \
+  --header 'fluree-policy: {"@context":{"f":"https://ns.flur.ee/ledger#"},"f:query":{"@type":"@json","@value":{"where":["filter","(= ?$this ?$identity)"]}}}' \
+  --data '{
+    "from": "my-ledger",
+    "select": { "?s": ["*"] },
+    "where": { "@id": "?s" }
+  }'
+```
+
+#### Policy Values Header
+
+Bind dynamic values for policy evaluation:
+
+```sh
+curl --location 'http://localhost:58090/fluree/query' \
+  --header 'Content-Type: application/json' \
+  --header 'fluree-identity: ex:alice' \
+  --header 'fluree-policy-values: {"department":"engineering"}' \
+  --data '{
+    "from": "my-ledger",
+    "select": { "?s": ["*"] },
+    "where": { "@id": "?s", "@type": "ex:Employee" }
+  }'
+```
+
+## Policy Values Binding
+
+Policy values allow you to pass dynamic parameters to policy queries. In your policy `f:query`, reference bound values with the `?$` prefix:
+
+```json
+{
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "where": [
+        { "@id": "?$this", "ex:department": "?dept" },
+        ["filter", "(= ?dept ?$department)"]
+      ]
+    }
+  }
+}
+```
+
+When evaluating this policy, pass the department value:
+
+```json
+{
+  "opts": {
+    "identity": "ex:alice",
+    "policy-values": {
+      "department": "engineering"
+    }
+  }
+}
+```
+
+## Default Allow Behavior
+
+By default, if no policies are defined, all data is accessible. When policies are added:
+
+- If no policy matches a flake, access is **denied**
+- At least one non-required policy must permit access, OR
+- All required policies must permit access
+
+To implement a default-allow pattern with specific restrictions, ensure you have a catch-all policy:
+
+```json
+{
+  "@id": "ex:defaultAllowPolicy",
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "where": ["filter", "true"]
+    }
+  }
+}
+```
+
+Then add required policies to restrict specific data.
+
+## Identity-Based Policy Patterns
+
+These examples demonstrate common patterns for user-specific access control.
+
+### Linking DIDs to Application Users
+
+A common pattern is to link a DID (used for authentication) to an application-level user entity:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/",
+    "schema": "http://schema.org/"
+  },
+  "insert": [
+    {
+      "@id": "ex:alice",
+      "@type": "ex:User",
+      "schema:name": "Alice",
+      "schema:email": "alice@example.com",
+      "schema:ssn": "111-11-1111"
+    },
+    {
+      "@id": "did:key:z6MkqtpqKGs4Et8mqBLBBAitDC1DPBiTJEbu26AcBX75B5rR",
+      "f:policyClass": [{"@id": "ex:UserPolicy"}],
+      "ex:user": {"@id": "ex:alice"}
+    }
+  ]
+}
+```
+
+The DID entity has:
+- `f:policyClass` — Links to policy classes that apply to this identity
+- `ex:user` — Custom property linking to the application user
+
+### Property-Level Identity Restriction
+
+Restrict sensitive properties so users can only see their own data:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/",
+    "schema": "http://schema.org/"
+  },
+  "insert": [
+    {
+      "@id": "ex:ssnRestriction",
+      "@type": ["f:AccessPolicy", "ex:UserPolicy"],
+      "f:required": true,
+      "f:onProperty": [{"@id": "schema:ssn"}],
+      "f:action": {"@id": "f:view"},
+      "f:query": {
+        "@type": "@json",
+        "@value": {
+          "@context": {"ex": "http://example.org/"},
+          "where": {
+            "@id": "?$identity",
+            "ex:user": {"@id": "?$this"}
+          }
+        }
+      }
+    },
+    {
+      "@id": "ex:defaultAllow",
+      "@type": ["f:AccessPolicy", "ex:UserPolicy"],
+      "f:action": {"@id": "f:view"},
+      "f:query": {"@type": "@json", "@value": {}}
+    }
+  ]
+}
+```
+
+How this works:
+1. `ex:ssnRestriction` is marked `f:required` — it must pass for SSN access
+2. The query checks if `?$identity` (the DID) has `ex:user` pointing to `?$this` (the entity with the SSN)
+3. `ex:defaultAllow` permits viewing other data without restriction
+4. Result: Users can see all data, but only their own SSN
+
+### Query Behavior with Identity Policies
+
+When querying with an identity that has the above policies:
+
+```json
+{
+  "from": "my-ledger",
+  "select": {"?s": ["*"]},
+  "where": {"@id": "?s", "@type": "ex:User"},
+  "opts": {
+    "identity": "did:key:z6MkqtpqKGs4Et8mqBLBBAitDC1DPBiTJEbu26AcBX75B5rR"
+  }
+}
+```
+
+Returns:
+```json
+[
+  {
+    "@id": "ex:alice",
+    "@type": "ex:User",
+    "schema:name": "Alice",
+    "schema:email": "alice@example.com",
+    "schema:ssn": "111-11-1111"
+  },
+  {
+    "@id": "ex:bob",
+    "@type": "ex:User",
+    "schema:name": "Bob",
+    "schema:email": "bob@example.com"
+  }
+]
+```
+
+Alice sees her own SSN, but Bob's SSN is filtered out.
+
+### User Can Only Modify Own Data
+
+Restrict modifications so users can only change their own records:
+
+```json
+{
+  "@id": "ex:modifyOwnDataOnly",
+  "@type": ["f:AccessPolicy", "ex:UserPolicy"],
+  "f:required": true,
+  "f:action": {"@id": "f:modify"},
+  "f:exMessage": "You can only modify your own data",
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": {"ex": "http://example.org/"},
+      "where": {
+        "@id": "?$identity",
+        "ex:user": {"@id": "?$this"}
+      }
+    }
+  }
+}
+```
+
+### Team-Based Access
+
+Allow users to access data belonging to their team:
+
+```json
+{
+  "@id": "ex:teamAccess",
+  "@type": ["f:AccessPolicy", "ex:UserPolicy"],
+  "f:action": {"@id": "f:view"},
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": {"ex": "http://example.org/"},
+      "where": [
+        {"@id": "?$identity", "ex:user": "?user"},
+        {"@id": "?user", "ex:team": "?team"},
+        {"@id": "?$this", "ex:team": "?team"}
+      ]
+    }
+  }
+}
+```
+
+This allows access when:
+1. The identity's linked user belongs to a team
+2. The target entity belongs to the same team
+
+### Hierarchical Access (Manager Can See Reports)
+
+Allow managers to see data of their direct reports:
+
+```json
+{
+  "@id": "ex:managerAccess",
+  "@type": ["f:AccessPolicy", "ex:UserPolicy"],
+  "f:action": {"@id": "f:view"},
+  "f:query": {
+    "@type": "@json",
+    "@value": {
+      "@context": {"ex": "http://example.org/"},
+      "where": [
+        {"@id": "?$identity", "ex:user": "?manager"},
+        {"@id": "?$this", "ex:reportsTo": {"@id": "?manager"}}
+      ]
+    }
+  }
+}
+```

--- a/docs/reference/reasoning.mdx
+++ b/docs/reference/reasoning.mdx
@@ -1,0 +1,346 @@
+# Reasoning and Inference
+
+Fluree supports semantic reasoning, allowing you to derive new facts from existing data using rules and ontologies. Reasoning is performed in-memory and does not modify persisted data.
+
+Reasoning works hand-in-hand with your [data model](/docs/learn/modeling/classes-and-properties/)—the classes, properties, and relationships you define using RDFS and OWL vocabularies become the basis for inference. For example, if you define that `Dog` is a subclass of `Mammal`, reasoning can automatically infer that all dogs are mammals.
+
+---
+
+## Overview
+
+Fluree supports three reasoning methods:
+
+| Method | Description |
+|--------|-------------|
+| `datalog` | Custom forward-chaining rules using JSON-LD format |
+| `owl2rl` | OWL 2 RL profile with automatic rule generation from OWL constructs |
+| `owl-datalog` | Extended OWL 2 RL with additional Datalog-compatible constructs |
+
+Reasoning is applied to a database snapshot and returns a new database value that includes inferred facts.
+
+---
+
+## Using Reasoning in Queries
+
+To use reasoning with HTTP API queries, include the `opts` object with reasoning configuration:
+
+```json
+{
+  "from": "my-ledger",
+  "select": { "?s": ["*"] },
+  "where": { "@id": "?s", "@type": "ex:Person" },
+  "opts": {
+    "reasoner": ["datalog"]
+  }
+}
+```
+
+### Reasoning Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `reasoner` | array | Reasoning methods to apply: `"datalog"`, `"owl2rl"`, or `"owl-datalog"` |
+| `reasoner-max` | integer | Maximum reasoning iterations (default: 10) |
+
+---
+
+## Datalog Rules
+
+Datalog rules are custom forward-chaining rules stored as JSON-LD entities in your ledger.
+
+### Rule Structure
+
+Rules are stored as entities with a `f:rule` property containing a JSON-LD rule definition:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:uncleRule",
+  "f:rule": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": {
+        "@id": "?person",
+        "ex:parents": {
+          "ex:brother": { "@id": "?pBrother" }
+        }
+      },
+      "insert": {
+        "@id": "?person",
+        "ex:uncle": "?pBrother"
+      }
+    }
+  }
+}
+```
+
+### Rule Syntax
+
+A rule has two main clauses:
+
+| Clause | Description |
+|--------|-------------|
+| `where` | Pattern to match against existing data (uses logic variables starting with `?`) |
+| `insert` | Data to assert when the pattern matches |
+
+### Example: Senior Citizen Rule
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "ex": "http://example.org/"
+  },
+  "@id": "ex:seniorRule",
+  "f:rule": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "ex": "http://example.org/" },
+      "where": [
+        { "@id": "?person", "ex:age": "?age" },
+        ["filter", "(>= ?age 62)"]
+      ],
+      "insert": { "@id": "?person", "ex:seniorCitizen": true }
+    }
+  }
+}
+```
+
+This rule infers that any person aged 62 or older is a senior citizen.
+
+### Filter Expressions
+
+Rules can include filter expressions for conditional matching:
+
+```json
+"where": [
+  { "@id": "?person", "ex:salary": "?salary" },
+  ["filter", "(> ?salary 100000)"]
+]
+```
+
+Available filter functions are the same as those in [FlureeQL queries](/docs/reference/querying/where-clauses/#valid-functions-for-use-in-filter-and-bind-expressions).
+
+---
+
+## OWL 2 RL Reasoning
+
+OWL 2 RL reasoning automatically generates inference rules from OWL constructs in your data. This is useful when you have an OWL ontology and want automatic semantic inference.
+
+### Using OWL 2 RL
+
+```json
+{
+  "from": "my-ledger",
+  "select": { "?s": ["*"] },
+  "where": { "@id": "?s", "@type": "ex:Person" },
+  "opts": {
+    "reasoner": ["owl2rl"]
+  }
+}
+```
+
+### Supported OWL Constructs
+
+#### Property Axioms
+
+| Construct | Effect |
+|-----------|--------|
+| `rdfs:domain` | Infers type from property usage |
+| `rdfs:range` | Infers type on property objects |
+| `rdfs:subPropertyOf` | Property hierarchy inheritance |
+| `owl:inverseOf` | Bidirectional property inference |
+| `owl:propertyChainAxiom` | Complex property chains |
+
+#### Property Characteristics
+
+| Construct | Effect |
+|-----------|--------|
+| `owl:FunctionalProperty` | Single-valued constraint |
+| `owl:InverseFunctionalProperty` | Unique inverse values |
+| `owl:SymmetricProperty` | Bidirectional relationships |
+| `owl:TransitiveProperty` | Transitive closure |
+
+#### Class Axioms
+
+| Construct | Effect |
+|-----------|--------|
+| `rdfs:subClassOf` | Class hierarchy inheritance |
+| `owl:equivalentClass` | Class equivalence |
+| `owl:intersectionOf` | Class intersection |
+| `owl:unionOf` | Class union |
+
+#### Equality
+
+| Construct | Effect |
+|-----------|--------|
+| `owl:sameAs` | Entity equivalence (properties are merged) |
+
+### Example: Domain and Range Inference
+
+Define an ontology:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+  },
+  "@id": "ex:worksFor",
+  "@type": "owl:ObjectProperty",
+  "rdfs:domain": { "@id": "ex:Employee" },
+  "rdfs:range": { "@id": "ex:Organization" }
+}
+```
+
+With this ontology, when you assert:
+
+```json
+{ "@id": "ex:alice", "ex:worksFor": { "@id": "ex:acme" } }
+```
+
+OWL 2 RL reasoning will infer:
+
+```json
+{ "@id": "ex:alice", "@type": "ex:Employee" }
+{ "@id": "ex:acme", "@type": "ex:Organization" }
+```
+
+### Example: Transitive Properties
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "owl": "http://www.w3.org/2002/07/owl#"
+  },
+  "@id": "ex:ancestorOf",
+  "@type": ["owl:ObjectProperty", "owl:TransitiveProperty"]
+}
+```
+
+With data:
+
+```json
+[
+  { "@id": "ex:alice", "ex:ancestorOf": { "@id": "ex:bob" } },
+  { "@id": "ex:bob", "ex:ancestorOf": { "@id": "ex:charlie" } }
+]
+```
+
+Reasoning infers: `ex:alice ex:ancestorOf ex:charlie`
+
+---
+
+## OWL-Datalog Reasoning
+
+OWL-Datalog extends OWL 2 RL with additional constructs that can be expressed in Datalog. This includes:
+
+- Complex `owl:equivalentClass` with intersections containing restrictions
+- Blank node restrictions in class definitions
+- Enhanced `owl:someValuesFrom` reasoning
+
+Use this method when you need more expressive reasoning than OWL 2 RL alone.
+
+```json
+{
+  "opts": {
+    "reasoner": ["owl-datalog"]
+  }
+}
+```
+
+---
+
+## Combining Reasoning Methods
+
+You can apply multiple reasoning methods in sequence:
+
+```json
+{
+  "opts": {
+    "reasoner": ["datalog", "owl2rl"]
+  }
+}
+```
+
+Methods are applied in order, with each method seeing the results of previous methods.
+
+---
+
+## Reasoning Execution
+
+### Iteration Model
+
+Reasoning executes iteratively:
+
+1. Rules are extracted from the database (Datalog) or ontology (OWL)
+2. Rules are scheduled based on dependencies
+3. Rules execute and generate new facts
+4. Process repeats until no new facts are generated or max iterations reached
+
+### Controlling Iterations
+
+Set `reasoner-max` to control maximum iterations:
+
+```json
+{
+  "opts": {
+    "reasoner": ["datalog"],
+    "reasoner-max": 5
+  }
+}
+```
+
+The default is 10 iterations.
+
+---
+
+## External Rules
+
+You can provide rules directly in the query without storing them in the ledger:
+
+```json
+{
+  "from": "my-ledger",
+  "select": { "?s": ["*"] },
+  "where": { "@id": "?s", "ex:seniorCitizen": true },
+  "opts": {
+    "reasoner": ["datalog"],
+    "rules": [
+      {
+        "@context": { "ex": "http://example.org/" },
+        "where": [
+          { "@id": "?person", "ex:age": "?age" },
+          ["filter", "(>= ?age 62)"]
+        ],
+        "insert": { "@id": "?person", "ex:seniorCitizen": true }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Best Practices
+
+1. **Start Simple**: Begin with basic Datalog rules before moving to OWL reasoning
+2. **Test Incrementally**: Add rules one at a time to understand their effects
+3. **Limit Iterations**: Set appropriate `reasoner-max` values for complex rule sets
+4. **Use External Rules**: For ad-hoc reasoning, pass rules directly rather than storing them
+5. **Monitor Performance**: Reasoning adds computational overhead; profile queries as needed
+
+---
+
+## Limitations
+
+- Reasoning is in-memory only; inferred facts are not persisted
+- OWL 2 RL is a subset of OWL 2; not all OWL constructs are supported
+- Complex rule sets may require multiple iterations
+- Very large datasets may impact reasoning performance

--- a/docs/reference/shacl-validation.mdx
+++ b/docs/reference/shacl-validation.mdx
@@ -1,0 +1,382 @@
+# SHACL Validation
+
+<div class="overview">
+  SHACL (Shapes Constraint Language) is a W3C standard for validating RDF graphs. Fluree supports SHACL shapes to enforce data integrity constraints on your ledger.
+</div>
+
+---
+
+## Overview
+
+SHACL shapes define constraints that data must conform to when inserted or updated. When a transaction violates a SHACL constraint, Fluree rejects the transaction with a detailed validation report.
+
+Key concepts:
+- **Shapes** define constraints on data
+- **Target classes** specify which entities a shape applies to
+- **Property constraints** validate specific properties
+- **Validation reports** explain what went wrong
+
+## Defining Shapes
+
+Shapes are defined by inserting entities of type `sh:NodeShape`:
+
+```json
+{
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "http://schema.org/",
+    "ex": "http://example.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "insert": {
+    "@id": "ex:UserShape",
+    "@type": "sh:NodeShape",
+    "sh:targetClass": {"@id": "ex:User"},
+    "sh:property": [
+      {
+        "sh:path": {"@id": "schema:name"},
+        "sh:minCount": 1,
+        "sh:maxCount": 1,
+        "sh:datatype": {"@id": "xsd:string"}
+      }
+    ]
+  }
+}
+```
+
+Once defined, the shape applies to all entities of the target class.
+
+## Property Constraints
+
+### Cardinality
+
+Control how many values a property can have:
+
+| Constraint | Description | Example |
+|------------|-------------|---------|
+| `sh:minCount` | Minimum number of values | `"sh:minCount": 1` (required) |
+| `sh:maxCount` | Maximum number of values | `"sh:maxCount": 1` (single value) |
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:email"},
+    "sh:minCount": 1,
+    "sh:maxCount": 1
+  }]
+}
+```
+
+### Datatype
+
+Require values to be a specific datatype:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:age"},
+    "sh:datatype": {"@id": "xsd:integer"}
+  }]
+}
+```
+
+Common datatypes:
+- `xsd:string` — Text values
+- `xsd:integer` — Whole numbers
+- `xsd:decimal` — Decimal numbers
+- `xsd:boolean` — True/false
+- `xsd:date` — Date values
+- `xsd:dateTime` — Date and time values
+
+### Numeric Ranges
+
+Constrain numeric values to a range:
+
+| Constraint | Description |
+|------------|-------------|
+| `sh:minInclusive` | Minimum value (inclusive) |
+| `sh:maxInclusive` | Maximum value (inclusive) |
+| `sh:minExclusive` | Minimum value (exclusive) |
+| `sh:maxExclusive` | Maximum value (exclusive) |
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:age"},
+    "sh:minInclusive": 0,
+    "sh:maxInclusive": 150
+  }]
+}
+```
+
+### String Constraints
+
+Validate string properties:
+
+| Constraint | Description |
+|------------|-------------|
+| `sh:minLength` | Minimum string length |
+| `sh:maxLength` | Maximum string length |
+| `sh:pattern` | Regex pattern to match |
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:email"},
+    "sh:pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+  }]
+}
+```
+
+### Enumerated Values
+
+Restrict values to a specific set using `sh:in`:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "ex:status"},
+    "sh:in": ["active", "inactive", "pending"]
+  }]
+}
+```
+
+### Class Membership
+
+Require referenced entities to be of a specific class:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:author"},
+    "sh:class": {"@id": "schema:Person"}
+  }]
+}
+```
+
+### Node Kind
+
+Specify whether values should be IRIs or literals:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:knows"},
+    "sh:nodeKind": {"@id": "sh:IRI"}
+  }]
+}
+```
+
+Node kinds:
+- `sh:IRI` — Must be a reference (IRI)
+- `sh:Literal` — Must be a literal value
+- `sh:BlankNode` — Must be a blank node
+
+## Property Pairs
+
+Compare values between properties:
+
+### sh:equals
+
+Require two properties to have the same values:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "ex:displayName"},
+    "sh:equals": {"@id": "schema:name"}
+  }]
+}
+```
+
+### sh:disjoint
+
+Require two properties to have no common values:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "ex:primaryEmail"},
+    "sh:disjoint": {"@id": "ex:secondaryEmail"}
+  }]
+}
+```
+
+## Closed Shapes
+
+Prevent entities from having properties not declared in the shape:
+
+```json
+{
+  "@id": "ex:StrictUserShape",
+  "@type": "sh:NodeShape",
+  "sh:targetClass": {"@id": "ex:User"},
+  "sh:closed": true,
+  "sh:ignoredProperties": [{"@id": "rdf:type"}],
+  "sh:property": [
+    {"sh:path": {"@id": "schema:name"}},
+    {"sh:path": {"@id": "schema:email"}}
+  ]
+}
+```
+
+With `sh:closed: true`, any property not listed in `sh:property` or `sh:ignoredProperties` will cause a validation error.
+
+> **NOTE**: The `rdf:type` property (or `@type` in JSON-LD) should typically be in `sh:ignoredProperties` since it's used to trigger the shape itself.
+
+## Logical Constraints
+
+Combine constraints using logical operators:
+
+### sh:not
+
+Ensure data does NOT conform to a shape:
+
+```json
+{
+  "@id": "ex:NonEmployeeShape",
+  "@type": "sh:NodeShape",
+  "sh:targetClass": {"@id": "ex:Person"},
+  "sh:not": [{
+    "sh:path": {"@id": "ex:employeeId"},
+    "sh:minCount": 1
+  }]
+}
+```
+
+This shape ensures persons do NOT have an employee ID.
+
+### sh:or
+
+Require at least one of several constraints to be satisfied:
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "ex:contact"},
+    "sh:or": [
+      {"sh:datatype": {"@id": "xsd:string"}},
+      {"sh:nodeKind": {"@id": "sh:IRI"}}
+    ]
+  }]
+}
+```
+
+### sh:and
+
+Require all constraints to be satisfied (useful for combining):
+
+```json
+{
+  "sh:property": [{
+    "sh:path": {"@id": "schema:age"},
+    "sh:and": [
+      {"sh:minInclusive": 18},
+      {"sh:maxInclusive": 65}
+    ]
+  }]
+}
+```
+
+## Validation Reports
+
+When a transaction violates SHACL constraints, Fluree returns an error with a validation report:
+
+```json
+{
+  "status": 422,
+  "error": "shacl/violation",
+  "report": {
+    "@type": "sh:ValidationReport",
+    "sh:conforms": false,
+    "sh:result": [
+      {
+        "@type": "sh:ValidationResult",
+        "sh:resultSeverity": "sh:Violation",
+        "sh:focusNode": "ex:john",
+        "sh:constraintComponent": "sh:minCount",
+        "sh:sourceShape": "ex:UserShape",
+        "sh:resultPath": ["schema:name"],
+        "sh:value": 0,
+        "f:expectation": 1,
+        "sh:resultMessage": "count 0 is less than minimum count of 1"
+      }
+    ]
+  }
+}
+```
+
+### Report Fields
+
+| Field | Description |
+|-------|-------------|
+| `sh:focusNode` | The entity that failed validation |
+| `sh:constraintComponent` | The constraint that was violated |
+| `sh:sourceShape` | The shape that defined the constraint |
+| `sh:resultPath` | The property path that failed |
+| `sh:value` | The actual value found |
+| `f:expectation` | The expected value |
+| `sh:resultMessage` | Human-readable error message |
+
+## Complete Example
+
+Here's a comprehensive example with multiple constraints:
+
+```json
+{
+  "@context": {
+    "sh": "http://www.w3.org/ns/shacl#",
+    "schema": "http://schema.org/",
+    "ex": "http://example.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "insert": {
+    "@id": "ex:PersonShape",
+    "@type": "sh:NodeShape",
+    "sh:targetClass": {"@id": "ex:Person"},
+    "sh:property": [
+      {
+        "@id": "ex:nameConstraint",
+        "sh:path": {"@id": "schema:name"},
+        "sh:minCount": 1,
+        "sh:maxCount": 1,
+        "sh:datatype": {"@id": "xsd:string"},
+        "sh:minLength": 2,
+        "sh:maxLength": 100
+      },
+      {
+        "@id": "ex:emailConstraint",
+        "sh:path": {"@id": "schema:email"},
+        "sh:maxCount": 3,
+        "sh:pattern": "^[^@]+@[^@]+\\.[^@]+$"
+      },
+      {
+        "@id": "ex:ageConstraint",
+        "sh:path": {"@id": "schema:age"},
+        "sh:datatype": {"@id": "xsd:integer"},
+        "sh:minInclusive": 0,
+        "sh:maxInclusive": 150
+      },
+      {
+        "@id": "ex:statusConstraint",
+        "sh:path": {"@id": "ex:status"},
+        "sh:in": ["active", "inactive", "pending"]
+      }
+    ]
+  }
+}
+```
+
+This shape ensures:
+- Name is required, single-valued, string between 2-100 characters
+- Email is optional but max 3 values, must match email pattern
+- Age is optional but must be integer 0-150
+- Status must be one of the allowed values
+
+## Best Practices
+
+1. **Give shapes and property constraints IDs** — Makes validation reports more readable
+2. **Use `sh:message`** — Add custom error messages for better debugging
+3. **Start permissive, add constraints gradually** — Easier to tighten than loosen
+4. **Test constraints before deploying** — Ensure they don't block valid data
+5. **Consider `sh:severity`** — Use `sh:Warning` for non-blocking validation

--- a/docs/reference/sparql-syntax.md
+++ b/docs/reference/sparql-syntax.md
@@ -1,0 +1,316 @@
+# SPARQL Query Syntax
+
+Fluree supports a subset of the W3C SPARQL 1.1 standard for querying and updating data. SPARQL can be used as an alternative to FlureeQL for users familiar with RDF databases.
+
+---
+
+## Using SPARQL
+
+To use SPARQL queries, set the `Content-Type` header appropriately:
+
+- `application/sparql-query` for SELECT and CONSTRUCT queries
+- `application/sparql-update` for INSERT and DELETE operations
+
+You must also specify the target ledger using the `fluree-ledger` header.
+
+---
+
+## SELECT Queries
+
+SELECT queries return tabular results.
+
+### Basic SELECT
+
+```sparql
+SELECT ?s ?name
+WHERE {
+  ?s <ex:name> ?name
+}
+```
+
+### Curl Example
+
+```sh
+curl --location 'http://localhost:58090/fluree/query' \
+  --header 'Content-Type: application/sparql-query' \
+  --header 'fluree-ledger: my-ledger' \
+  --data 'SELECT ?s ?name WHERE { ?s <ex:name> ?name }'
+```
+
+### Example Response
+
+```json
+[
+  ["ex:alice", "Alice"],
+  ["ex:bob", "Bob"]
+]
+```
+
+### With FILTER
+
+```sparql
+SELECT ?s ?age
+WHERE {
+  ?s <ex:age> ?age .
+  FILTER(?age > 21)
+}
+```
+
+### With OPTIONAL
+
+```sparql
+SELECT ?s ?name ?email
+WHERE {
+  ?s <ex:name> ?name .
+  OPTIONAL { ?s <ex:email> ?email }
+}
+```
+
+### With ORDER BY and LIMIT
+
+```sparql
+SELECT ?s ?name
+WHERE {
+  ?s <ex:name> ?name
+}
+ORDER BY ?name
+LIMIT 10
+```
+
+---
+
+## CONSTRUCT Queries
+
+CONSTRUCT queries build RDF graphs from query results, returned as JSON-LD.
+
+### Basic CONSTRUCT
+
+```sparql
+CONSTRUCT {
+  ?s a <ex:SearchResult> ;
+     <ex:displayName> ?name .
+}
+WHERE {
+  ?s <ex:name> ?name
+}
+```
+
+### Curl Example
+
+```sh
+curl --location 'http://localhost:58090/fluree/query' \
+  --header 'Content-Type: application/sparql-query' \
+  --header 'fluree-ledger: my-ledger' \
+  --data 'CONSTRUCT { ?s a <ex:Result> ; <ex:displayName> ?name } WHERE { ?s <ex:name> ?name }'
+```
+
+### Example Response
+
+```json
+{
+  "@graph": [
+    {
+      "@id": "ex:alice",
+      "@type": ["ex:Result"],
+      "ex:displayName": ["Alice"]
+    },
+    {
+      "@id": "ex:bob",
+      "@type": ["ex:Result"],
+      "ex:displayName": ["Bob"]
+    }
+  ],
+  "@context": {}
+}
+```
+
+---
+
+## UPDATE Operations
+
+SPARQL UPDATE is used to insert, delete, or modify data.
+
+### INSERT DATA
+
+Insert specific triples without pattern matching:
+
+```sparql
+INSERT DATA {
+  <ex:alice> <ex:name> "Alice" .
+  <ex:alice> <ex:age> 30 .
+  <ex:alice> a <ex:Person> .
+}
+```
+
+### Curl Example
+
+```sh
+curl --location 'http://localhost:58090/fluree/transact' \
+  --header 'Content-Type: application/sparql-update' \
+  --header 'fluree-ledger: my-ledger' \
+  --data 'INSERT DATA { <ex:alice> <ex:name> "Alice" . <ex:alice> <ex:age> 30 }'
+```
+
+### DELETE DATA
+
+Delete specific triples without pattern matching:
+
+```sparql
+DELETE DATA {
+  <ex:alice> <ex:name> "Alice"
+}
+```
+
+### DELETE/INSERT WHERE
+
+Conditional updates using pattern matching:
+
+```sparql
+DELETE {
+  ?s <ex:name> ?oldName
+}
+INSERT {
+  ?s <ex:name> "Alice Smith"
+}
+WHERE {
+  ?s <ex:name> ?oldName .
+  FILTER(?oldName = "Alice")
+}
+```
+
+### Curl Example
+
+```sh
+curl --location 'http://localhost:58090/fluree/transact' \
+  --header 'Content-Type: application/sparql-update' \
+  --header 'fluree-ledger: my-ledger' \
+  --data 'DELETE { ?s <ex:name> ?old } INSERT { ?s <ex:name> "New Name" } WHERE { ?s <ex:name> ?old . FILTER(?old = "Old Name") }'
+```
+
+---
+
+## Supported SPARQL Features
+
+Fluree supports a subset of SPARQL 1.1. Here's what's available:
+
+### Query Forms
+
+| Form | Supported | Notes |
+|------|-----------|-------|
+| SELECT | Yes | Full support |
+| CONSTRUCT | Yes | Returns JSON-LD |
+| ASK | No | Not implemented |
+| DESCRIBE | No | Not implemented |
+
+### Graph Patterns
+
+| Pattern | Supported |
+|---------|-----------|
+| Basic Graph Pattern | Yes |
+| OPTIONAL | Yes |
+| UNION | Yes |
+| FILTER | Yes |
+| BIND | Yes |
+
+### Solution Modifiers
+
+| Modifier | Supported |
+|----------|-----------|
+| ORDER BY | Yes |
+| LIMIT | Yes |
+| OFFSET | Yes |
+| DISTINCT | Yes |
+
+### Update Operations
+
+| Operation | Supported |
+|-----------|-----------|
+| INSERT DATA | Yes |
+| DELETE DATA | Yes |
+| DELETE/INSERT WHERE | Yes |
+| LOAD | No |
+| CLEAR | No |
+| DROP | No |
+
+### Functions
+
+SPARQL filter functions are generally supported. Common functions include:
+
+- Comparison: `=`, `!=`, `<`, `>`, `<=`, `>=`
+- Logical: `&&`, `||`, `!`
+- String: `STRLEN`, `STRSTARTS`, `STRENDS`, `CONTAINS`
+- Numeric: `ABS`, `ROUND`, `CEIL`, `FLOOR`
+- Type checking: `isIRI`, `isBlank`, `isLiteral`, `isNumeric`
+
+---
+
+## IRI Syntax
+
+In SPARQL queries against Fluree, you can use:
+
+### Full IRIs
+
+```sparql
+SELECT ?s WHERE { ?s <http://example.org/name> ?name }
+```
+
+### Prefixed Names
+
+Use PREFIX declarations for more readable queries:
+
+```sparql
+PREFIX ex: <http://example.org/>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?s ?name
+WHERE {
+  ?s a ex:Person ;
+     schema:name ?name .
+}
+```
+
+### Abbreviated IRIs
+
+Fluree also accepts abbreviated IRIs without full namespace declarations when the context is known:
+
+```sparql
+SELECT ?s WHERE { ?s <ex:name> ?name }
+```
+
+---
+
+## Response Formats
+
+By default, SPARQL query results are returned as JSON arrays. You can control the output format using the `fluree-output` header:
+
+- `fql` (default) - JSON array format
+- `sparql` - SPARQL Results JSON format
+
+### FQL Format (Default)
+
+```json
+[
+  ["ex:alice", "Alice"],
+  ["ex:bob", "Bob"]
+]
+```
+
+### SPARQL Results JSON Format
+
+When using `fluree-output: sparql`:
+
+```json
+{
+  "head": {
+    "vars": ["s", "name"]
+  },
+  "results": {
+    "bindings": [
+      {
+        "s": { "type": "uri", "value": "http://example.org/alice" },
+        "name": { "type": "literal", "value": "Alice" }
+      }
+    ]
+  }
+}
+```

--- a/docs/reference/transaction-syntax.mdx
+++ b/docs/reference/transaction-syntax.mdx
@@ -73,6 +73,159 @@ Arbitrarily nested JSON-LD is also supported:
 
 See [the W3C standard for JSON-LD](https://www.w3.org/TR/json-ld11/) for more information on structuring JSON-LD objects.
 
+## Multi-Value Properties: @set vs @list
+
+In Fluree, properties can have multiple values. By default, multi-value properties use **set semantics** (`@set`), meaning values are unordered and unique. For ordered collections, use **list semantics** (`@list`).
+
+### Default Behavior: @set (Unordered)
+
+By default, when you provide an array of values, Fluree treats them as an unordered set:
+
+```json
+{
+  "ledger": "my-ledger",
+  "insert": {
+    "@id": "ex:movie1",
+    "ex:starring": ["Alice", "Bob", "Charlie"]
+  }
+}
+```
+
+**Set characteristics:**
+- **Unordered** — Query results may return values in any order
+- **Unique** — Duplicate values are automatically deduplicated
+- **Efficient** — Optimized for membership testing and updates
+
+When querying, the order of values is not guaranteed:
+```json
+["Charlie", "Alice", "Bob"]  // Order may vary
+```
+
+### Ordered Collections: @list
+
+When order matters, use the `@list` container. Define it in your context:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:playlist": {"@container": "@list"}
+  },
+  "ledger": "my-ledger",
+  "insert": {
+    "@id": "ex:myPlaylist",
+    "ex:playlist": ["Song A", "Song B", "Song C"]
+  }
+}
+```
+
+**List characteristics:**
+- **Ordered** — Values maintain their sequence
+- **Allows duplicates** — The same value can appear multiple times
+- **Atomic updates** — Must replace entire list to modify
+
+When querying, the order is preserved:
+```json
+["Song A", "Song B", "Song C"]  // Order guaranteed
+```
+
+### Inline @list Syntax
+
+You can also specify `@list` inline without modifying the context:
+
+```json
+{
+  "ledger": "my-ledger",
+  "insert": {
+    "@id": "ex:recipe1",
+    "ex:steps": {
+      "@list": ["Preheat oven", "Mix ingredients", "Bake for 30 min"]
+    }
+  }
+}
+```
+
+### Lists with Object References
+
+Lists can contain references to other entities:
+
+```json
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "ex:orderedFriends": {"@container": "@list"}
+  },
+  "ledger": "my-ledger",
+  "insert": [
+    {"@id": "ex:alice", "ex:name": "Alice"},
+    {"@id": "ex:bob", "ex:name": "Bob"},
+    {
+      "@id": "ex:charlie",
+      "ex:name": "Charlie",
+      "ex:orderedFriends": [
+        {"@id": "ex:alice"},
+        {"@id": "ex:bob"}
+      ]
+    }
+  ]
+}
+```
+
+### When to Use Each
+
+| Use Case | Container | Reason |
+|----------|-----------|--------|
+| Tags, categories, roles | `@set` (default) | Order doesn't matter |
+| Cast members, authors | `@set` (default) | Membership is what matters |
+| Playlist, queue, steps | `@list` | Sequence is important |
+| Priority ranking | `@list` | Position has meaning |
+| History, log entries | `@list` | Chronological order matters |
+
+### Updating Lists vs Sets
+
+**Sets** support incremental updates — you can add or remove individual values:
+
+```json
+{
+  "ledger": "my-ledger",
+  "insert": {
+    "@id": "ex:movie1",
+    "ex:starring": ["Diana"]
+  }
+}
+```
+
+This adds "Diana" to the existing cast without removing others.
+
+**Lists** require full replacement — you cannot insert at a specific position:
+
+```json
+{
+  "@context": {"ex:steps": {"@container": "@list"}},
+  "ledger": "my-ledger",
+  "where": {"@id": "ex:recipe1", "ex:steps": "?oldSteps"},
+  "delete": {"@id": "ex:recipe1", "ex:steps": "?oldSteps"},
+  "insert": {
+    "@id": "ex:recipe1",
+    "ex:steps": {
+      "@list": ["Preheat oven", "Grease pan", "Mix ingredients", "Bake for 30 min"]
+    }
+  }
+}
+```
+
+### Single Values
+
+When a property has only one value, both `@set` and `@list` return the value directly (not wrapped in an array):
+
+```json
+// Stored as @list with one item
+{"ex:playlist": ["Only Song"]}
+
+// Returns as single value
+{"ex:playlist": "Only Song"}
+```
+
 ## Sample Data & Ledger
 
 You can recreate and test each of the sample transactions in this page using the json objects below to create the "media" ledger and transact in your sample data.
@@ -164,7 +317,7 @@ In this example we will insert two records, one for the book Hyperion, and the o
 
 ## Transaction object: delete
 
-To delete a subject, the transaction object must include the `"delete"` key. We will also often use the `where` key to bind existing data to logic variables, and then use them to qualify the exact existing data to be retracted. [For more on the `where` clause, see our Reference Doc on FlureeQL Syntax](/docs/reference/flureeql-query-syntax/#where).
+To delete a subject, the transaction object must include the `"delete"` key. We will also often use the `where` key to bind existing data to logic variables, and then use them to qualify the exact existing data to be retracted. [For more on the `where` clause, see our Reference Doc on FlureeQL Syntax](/docs/reference/querying/where-clauses/).
 
 ### Deleting All Facts on a Subject
 


### PR DESCRIPTION
## Summary

Adds new reference documentation for Fluree features:

### New files
- **authentication.md**: Auth methods, JWT tokens, DID support
- **full-text-search.mdx**: Lucene integration and search syntax
- **reasoning.mdx**: OWL inference engine reference
- **shacl-validation.mdx**: SHACL shapes reference
- **sparql-syntax.md**: SPARQL query support

### Significantly expanded
- **error-codes.mdx**: Comprehensive error code reference
- **policy-syntax.mdx**: Complete policy rule documentation
- **transaction-syntax.mdx**: Full transaction format reference

### Minor updates
- **cloud-http-api.md**: Small fixes

## Test plan

- [ ] Verify new reference docs match implementation
- [ ] Check expanded docs cover all edge cases