### PR TITLE
docs: add domain example datasets

### DIFF
--- a/docs/examples/datasets/academic-credentials/introduction.mdx
+++ b/docs/examples/datasets/academic-credentials/introduction.mdx
@@ -41,7 +41,7 @@ The walkthrough also demonstrates core concepts for working with Fluree and sema
 - Specifying the shape of your query results using the `select` clause
 - Using the `where` and `union` clauses with logic variables to filter query results
 
-This walkthrough assumes that you've gone through [the tutorial](/docs/learn/tutorial/introduction).
+This walkthrough assumes that you're familiar with [Fluree basics](/docs/learn/).
 
 ## Schema Overview
 
@@ -141,7 +141,7 @@ Each time you refresh or come back to this page, the Sandbox is populated anew w
 You can add or delete whatever data you like and just refresh the page to get back to Square One.
 As you read through the articles, try clicking the **Freddy Button** in the top-right of each code block to drop the code into the Sandbox for your querying convenience!
 
-The other option is to clone the [Academic Credential Dataset git repo](https://github.com/fluree/dataset-academic-credentials) and follow the instructions in the [Introduction](/docs/learn/tutorial/introduction/) tutorial to run the ledger on your machine.
+The other option is to clone the [Academic Credential Dataset git repo](https://github.com/fluree/dataset-academic-credentials) and follow the instructions in the [Getting Started](/docs/getting-started/) guide to run the ledger on your machine.
 
     { /*
 
@@ -175,7 +175,7 @@ So, just to make sure no one is missing out, navigate to the [Academic Credentia
 }
 ```
 
-The `defaultContext` is used whenever you don't include an `@context` in your query or if you opt in to merging it with your provided `@context`. Check out [this article on `@context`](/docs/learn/guides/working-with-context) if you wanna learn more.
+The `defaultContext` is used whenever you don't include an `@context` in your query or if you opt in to merging it with your provided `@context`. Check out [this article on `@context`](/docs/learn/working-with-data/context-patterns/) if you wanna learn more.
 This `defaultContext` enables you to run a query like this:
 
 <SandboxButton />

--- a/docs/examples/datasets/academic-credentials/querying.mdx
+++ b/docs/examples/datasets/academic-credentials/querying.mdx
@@ -288,7 +288,7 @@ Luckily it's fairly basic and intuitive, as far as target schemas go. Check it o
 
 If we compare this schema to what our credentials currently look like in our latest resultset, we can see we have a bit more work to do.
 To deliver on this data request, we need to shift our attention from selecting nodes with the `where` clause, to "projecting" them with the `select` clause. "Projection" in this case is just a fancy way of saying "describe which properties we want to see for which nodes in our resultset".
-If you're interested in projection and how to build Fluree queries, check out the [reference](/docs/reference/flureeql-query-syntax/)!
+If you're interested in projection and how to build Fluree queries, check out the [reference](/docs/reference/querying/)!
 
 We need to expand a few referenced nodes in order to include all of the required fields we're missing.  
 Here's what that looks like:
@@ -353,7 +353,7 @@ I'll let the rude opinion slide and skip straight to the answer: we'll add an `@
 ### Querying the ACD with @context
 
 I'm sure you, my very attentive reader, have already picked up on my use of `@context` earlier in this article and
-I'm further sure, my very diligent reader, that you've already [read about `@context`](/docs/learn/tutorial/collaborative-data/#json-ld-context-and-compact-iris) and so you know that you can use `@context` in a query to sprinkle some delicious alias sugar into your resultset.
+I'm further sure, my very diligent reader, that you've already [read about `@context`](/docs/learn/advanced/collaborative-data/) and so you know that you can use `@context` in a query to sprinkle some delicious alias sugar into your resultset.
 Take a look at the same query with an `@context` that translates the keys in our resultset to exactly match those expected by Lucia's administrator.
 
 {/* <SandboxButton /> */}

--- a/docs/examples/datasets/ecommerce-seed-data/01_categories.json
+++ b/docs/examples/datasets/ecommerce-seed-data/01_categories.json
@@ -1,0 +1,74 @@
+[
+  {
+    "@id": "ecommerce-catalog",
+    "@graph": [
+      {
+        "id": "ecom:categories/electronics",
+        "type": "ecom:Category",
+        "schema:name": "Electronics",
+        "schema:description": "Electronic devices and accessories"
+      },
+      {
+        "id": "ecom:categories/electronics/phones",
+        "type": "ecom:Category",
+        "schema:name": "Phones",
+        "schema:description": "Smartphones and mobile devices",
+        "ecom:parentCategory": { "id": "ecom:categories/electronics" }
+      },
+      {
+        "id": "ecom:categories/electronics/phones/smartphones",
+        "type": "ecom:Category",
+        "schema:name": "Smartphones",
+        "schema:description": "Modern smartphones with touchscreens",
+        "ecom:parentCategory": { "id": "ecom:categories/electronics/phones" }
+      },
+      {
+        "id": "ecom:categories/electronics/laptops",
+        "type": "ecom:Category",
+        "schema:name": "Laptops",
+        "schema:description": "Portable computers",
+        "ecom:parentCategory": { "id": "ecom:categories/electronics" }
+      },
+      {
+        "id": "ecom:categories/electronics/audio",
+        "type": "ecom:Category",
+        "schema:name": "Audio",
+        "schema:description": "Headphones, speakers, and audio equipment",
+        "ecom:parentCategory": { "id": "ecom:categories/electronics" }
+      },
+      {
+        "id": "ecom:categories/clothing",
+        "type": "ecom:Category",
+        "schema:name": "Clothing",
+        "schema:description": "Apparel and fashion items"
+      },
+      {
+        "id": "ecom:categories/clothing/mens",
+        "type": "ecom:Category",
+        "schema:name": "Men's Clothing",
+        "schema:description": "Clothing for men",
+        "ecom:parentCategory": { "id": "ecom:categories/clothing" }
+      },
+      {
+        "id": "ecom:categories/clothing/womens",
+        "type": "ecom:Category",
+        "schema:name": "Women's Clothing",
+        "schema:description": "Clothing for women",
+        "ecom:parentCategory": { "id": "ecom:categories/clothing" }
+      },
+      {
+        "id": "ecom:categories/home",
+        "type": "ecom:Category",
+        "schema:name": "Home & Garden",
+        "schema:description": "Home goods and garden supplies"
+      },
+      {
+        "id": "ecom:categories/home/kitchen",
+        "type": "ecom:Category",
+        "schema:name": "Kitchen",
+        "schema:description": "Kitchen appliances and tools",
+        "ecom:parentCategory": { "id": "ecom:categories/home" }
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/ecommerce-seed-data/02_brands.json
+++ b/docs/examples/datasets/ecommerce-seed-data/02_brands.json
@@ -1,0 +1,42 @@
+[
+  {
+    "@id": "ecommerce-catalog",
+    "@graph": [
+      {
+        "id": "ecom:brands/techpro",
+        "type": "ecom:Brand",
+        "schema:name": "TechPro",
+        "schema:description": "Premium technology products",
+        "schema:url": "https://techpro.example.com"
+      },
+      {
+        "id": "ecom:brands/soundwave",
+        "type": "ecom:Brand",
+        "schema:name": "SoundWave",
+        "schema:description": "High-quality audio equipment",
+        "schema:url": "https://soundwave.example.com"
+      },
+      {
+        "id": "ecom:brands/urbanstyle",
+        "type": "ecom:Brand",
+        "schema:name": "UrbanStyle",
+        "schema:description": "Modern urban fashion",
+        "schema:url": "https://urbanstyle.example.com"
+      },
+      {
+        "id": "ecom:brands/homeessentials",
+        "type": "ecom:Brand",
+        "schema:name": "HomeEssentials",
+        "schema:description": "Quality home goods",
+        "schema:url": "https://homeessentials.example.com"
+      },
+      {
+        "id": "ecom:brands/nexgen",
+        "type": "ecom:Brand",
+        "schema:name": "NexGen",
+        "schema:description": "Next generation electronics",
+        "schema:url": "https://nexgen.example.com"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/ecommerce-seed-data/03_products.json
+++ b/docs/examples/datasets/ecommerce-seed-data/03_products.json
@@ -1,0 +1,310 @@
+[
+  {
+    "@id": "ecommerce-catalog",
+    "@graph": [
+      {
+        "id": "ecom:products/smartphone-pro-x",
+        "type": "ecom:Product",
+        "schema:name": "SmartPhone Pro X",
+        "schema:description": "Flagship smartphone with advanced camera system and all-day battery life. Features a stunning 6.7-inch OLED display.",
+        "schema:sku": "SPX-001",
+        "ecom:category": { "id": "ecom:categories/electronics/phones/smartphones" },
+        "ecom:brand": { "id": "ecom:brands/techpro" },
+        "ecom:basePrice": 999.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/spx-128-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Midnight Black",
+            "ecom:storage": "128GB",
+            "ecom:price": 999.99,
+            "ecom:stockQuantity": 45,
+            "schema:sku": "SPX-128-BLK"
+          },
+          {
+            "id": "ecom:variants/spx-256-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Midnight Black",
+            "ecom:storage": "256GB",
+            "ecom:price": 1099.99,
+            "ecom:stockQuantity": 32,
+            "schema:sku": "SPX-256-BLK"
+          },
+          {
+            "id": "ecom:variants/spx-128-silver",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Silver",
+            "ecom:storage": "128GB",
+            "ecom:price": 999.99,
+            "ecom:stockQuantity": 28,
+            "schema:sku": "SPX-128-SLV"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/smartphone-lite",
+        "type": "ecom:Product",
+        "schema:name": "SmartPhone Lite",
+        "schema:description": "Affordable smartphone with great performance. Perfect for everyday use with a crisp 6.1-inch display.",
+        "schema:sku": "SPL-001",
+        "ecom:category": { "id": "ecom:categories/electronics/phones/smartphones" },
+        "ecom:brand": { "id": "ecom:brands/techpro" },
+        "ecom:basePrice": 499.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/spl-64-blue",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Ocean Blue",
+            "ecom:storage": "64GB",
+            "ecom:price": 499.99,
+            "ecom:stockQuantity": 120,
+            "schema:sku": "SPL-64-BLU"
+          },
+          {
+            "id": "ecom:variants/spl-128-blue",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Ocean Blue",
+            "ecom:storage": "128GB",
+            "ecom:price": 549.99,
+            "ecom:stockQuantity": 85,
+            "schema:sku": "SPL-128-BLU"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/ultrabook-15",
+        "type": "ecom:Product",
+        "schema:name": "UltraBook 15",
+        "schema:description": "Thin and light 15-inch laptop with powerful performance. Ideal for professionals and creators.",
+        "schema:sku": "UB15-001",
+        "ecom:category": { "id": "ecom:categories/electronics/laptops" },
+        "ecom:brand": { "id": "ecom:brands/nexgen" },
+        "ecom:basePrice": 1299.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/ub15-i5-8gb",
+            "type": "ecom:ProductVariant",
+            "ecom:processor": "Intel i5",
+            "ecom:ram": "8GB",
+            "ecom:storage": "256GB SSD",
+            "ecom:price": 1299.99,
+            "ecom:stockQuantity": 22,
+            "schema:sku": "UB15-I5-8-256"
+          },
+          {
+            "id": "ecom:variants/ub15-i7-16gb",
+            "type": "ecom:ProductVariant",
+            "ecom:processor": "Intel i7",
+            "ecom:ram": "16GB",
+            "ecom:storage": "512GB SSD",
+            "ecom:price": 1699.99,
+            "ecom:stockQuantity": 15,
+            "schema:sku": "UB15-I7-16-512"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/wireless-headphones-elite",
+        "type": "ecom:Product",
+        "schema:name": "Wireless Headphones Elite",
+        "schema:description": "Premium noise-cancelling wireless headphones with 30-hour battery life and studio-quality sound.",
+        "schema:sku": "WHE-001",
+        "ecom:category": { "id": "ecom:categories/electronics/audio" },
+        "ecom:brand": { "id": "ecom:brands/soundwave" },
+        "ecom:basePrice": 349.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/whe-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Matte Black",
+            "ecom:price": 349.99,
+            "ecom:stockQuantity": 67,
+            "schema:sku": "WHE-BLK"
+          },
+          {
+            "id": "ecom:variants/whe-white",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Pearl White",
+            "ecom:price": 349.99,
+            "ecom:stockQuantity": 43,
+            "schema:sku": "WHE-WHT"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/earbuds-sport",
+        "type": "ecom:Product",
+        "schema:name": "SportBuds Pro",
+        "schema:description": "Sweat-resistant wireless earbuds designed for athletes. Secure fit and powerful bass.",
+        "schema:sku": "SBP-001",
+        "ecom:category": { "id": "ecom:categories/electronics/audio" },
+        "ecom:brand": { "id": "ecom:brands/soundwave" },
+        "ecom:basePrice": 149.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/sbp-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Black",
+            "ecom:price": 149.99,
+            "ecom:stockQuantity": 200,
+            "schema:sku": "SBP-BLK"
+          },
+          {
+            "id": "ecom:variants/sbp-red",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Racing Red",
+            "ecom:price": 149.99,
+            "ecom:stockQuantity": 0,
+            "schema:sku": "SBP-RED"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/classic-tee",
+        "type": "ecom:Product",
+        "schema:name": "Classic Cotton Tee",
+        "schema:description": "Comfortable 100% organic cotton t-shirt. Pre-shrunk and perfect for everyday wear.",
+        "schema:sku": "CCT-001",
+        "ecom:category": { "id": "ecom:categories/clothing/mens" },
+        "ecom:brand": { "id": "ecom:brands/urbanstyle" },
+        "ecom:basePrice": 29.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/cct-s-white",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "White",
+            "ecom:size": "S",
+            "ecom:price": 29.99,
+            "ecom:stockQuantity": 50,
+            "schema:sku": "CCT-S-WHT"
+          },
+          {
+            "id": "ecom:variants/cct-m-white",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "White",
+            "ecom:size": "M",
+            "ecom:price": 29.99,
+            "ecom:stockQuantity": 75,
+            "schema:sku": "CCT-M-WHT"
+          },
+          {
+            "id": "ecom:variants/cct-l-white",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "White",
+            "ecom:size": "L",
+            "ecom:price": 29.99,
+            "ecom:stockQuantity": 60,
+            "schema:sku": "CCT-L-WHT"
+          },
+          {
+            "id": "ecom:variants/cct-m-navy",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Navy",
+            "ecom:size": "M",
+            "ecom:price": 29.99,
+            "ecom:stockQuantity": 40,
+            "schema:sku": "CCT-M-NVY"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/denim-jacket",
+        "type": "ecom:Product",
+        "schema:name": "Vintage Denim Jacket",
+        "schema:description": "Classic denim jacket with a modern fit. Timeless style for any occasion.",
+        "schema:sku": "VDJ-001",
+        "ecom:category": { "id": "ecom:categories/clothing/womens" },
+        "ecom:brand": { "id": "ecom:brands/urbanstyle" },
+        "ecom:basePrice": 89.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/vdj-s-blue",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Classic Blue",
+            "ecom:size": "S",
+            "ecom:price": 89.99,
+            "ecom:stockQuantity": 18,
+            "schema:sku": "VDJ-S-BLU"
+          },
+          {
+            "id": "ecom:variants/vdj-m-blue",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Classic Blue",
+            "ecom:size": "M",
+            "ecom:price": 89.99,
+            "ecom:stockQuantity": 25,
+            "schema:sku": "VDJ-M-BLU"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/chef-knife-set",
+        "type": "ecom:Product",
+        "schema:name": "Professional Chef Knife Set",
+        "schema:description": "8-piece forged steel knife set with ergonomic handles. Includes chef's knife, santoku, paring knife, and more.",
+        "schema:sku": "CKS-001",
+        "ecom:category": { "id": "ecom:categories/home/kitchen" },
+        "ecom:brand": { "id": "ecom:brands/homeessentials" },
+        "ecom:basePrice": 199.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/cks-standard",
+            "type": "ecom:ProductVariant",
+            "ecom:price": 199.99,
+            "ecom:stockQuantity": 35,
+            "schema:sku": "CKS-STD"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/smart-blender",
+        "type": "ecom:Product",
+        "schema:name": "SmartBlend Pro",
+        "schema:description": "High-powered blender with smart presets for smoothies, soups, and nut butters. 1500W motor.",
+        "schema:sku": "SBP-001",
+        "ecom:category": { "id": "ecom:categories/home/kitchen" },
+        "ecom:brand": { "id": "ecom:brands/homeessentials" },
+        "ecom:basePrice": 149.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/sbp-silver",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Silver",
+            "ecom:price": 149.99,
+            "ecom:stockQuantity": 42,
+            "schema:sku": "SBP-SLV"
+          },
+          {
+            "id": "ecom:variants/sbp-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Black",
+            "ecom:price": 149.99,
+            "ecom:stockQuantity": 38,
+            "schema:sku": "SBP-BLK"
+          }
+        ]
+      },
+      {
+        "id": "ecom:products/gaming-phone",
+        "type": "ecom:Product",
+        "schema:name": "GamePhone Ultra",
+        "schema:description": "Gaming-focused smartphone with 144Hz display, advanced cooling, and shoulder triggers.",
+        "schema:sku": "GPU-001",
+        "ecom:category": { "id": "ecom:categories/electronics/phones/smartphones" },
+        "ecom:brand": { "id": "ecom:brands/nexgen" },
+        "ecom:basePrice": 799.99,
+        "ecom:variants": [
+          {
+            "id": "ecom:variants/gpu-256-black",
+            "type": "ecom:ProductVariant",
+            "ecom:color": "Stealth Black",
+            "ecom:storage": "256GB",
+            "ecom:price": 799.99,
+            "ecom:stockQuantity": 55,
+            "schema:sku": "GPU-256-BLK"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/ecommerce-seed-data/04_reviews.json
+++ b/docs/examples/datasets/ecommerce-seed-data/04_reviews.json
@@ -1,0 +1,195 @@
+[
+  {
+    "@id": "ecommerce-catalog",
+    "@graph": [
+      {
+        "id": "ecom:customers/alex",
+        "type": "ecom:Customer",
+        "schema:givenName": "Alex",
+        "schema:familyName": "Chen",
+        "schema:email": "alex.chen@example.com"
+      },
+      {
+        "id": "ecom:customers/jordan",
+        "type": "ecom:Customer",
+        "schema:givenName": "Jordan",
+        "schema:familyName": "Smith",
+        "schema:email": "jordan.smith@example.com"
+      },
+      {
+        "id": "ecom:customers/taylor",
+        "type": "ecom:Customer",
+        "schema:givenName": "Taylor",
+        "schema:familyName": "Williams",
+        "schema:email": "taylor.w@example.com"
+      },
+      {
+        "id": "ecom:customers/morgan",
+        "type": "ecom:Customer",
+        "schema:givenName": "Morgan",
+        "schema:familyName": "Johnson",
+        "schema:email": "morgan.j@example.com"
+      },
+      {
+        "id": "ecom:customers/casey",
+        "type": "ecom:Customer",
+        "schema:givenName": "Casey",
+        "schema:familyName": "Brown",
+        "schema:email": "casey.brown@example.com"
+      },
+      {
+        "id": "ecom:reviews/1",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smartphone-pro-x" },
+        "ecom:reviewer": { "id": "ecom:customers/alex" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Absolutely love this phone! The camera is incredible and battery lasts all day. Best phone I've ever owned.",
+        "schema:datePublished": "2024-11-15"
+      },
+      {
+        "id": "ecom:reviews/2",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smartphone-pro-x" },
+        "ecom:reviewer": { "id": "ecom:customers/jordan" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Great phone overall. Camera is amazing but wish it had more storage options. Still highly recommend.",
+        "schema:datePublished": "2024-11-20"
+      },
+      {
+        "id": "ecom:reviews/3",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smartphone-pro-x" },
+        "ecom:reviewer": { "id": "ecom:customers/taylor" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Switched from a competitor and I'm blown away. The display is stunning!",
+        "schema:datePublished": "2024-12-01"
+      },
+      {
+        "id": "ecom:reviews/4",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/wireless-headphones-elite" },
+        "ecom:reviewer": { "id": "ecom:customers/alex" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Best noise cancellation I've experienced. Perfect for my daily commute and working from cafes.",
+        "schema:datePublished": "2024-10-28"
+      },
+      {
+        "id": "ecom:reviews/5",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/wireless-headphones-elite" },
+        "ecom:reviewer": { "id": "ecom:customers/morgan" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Sound quality is excellent. Comfortable for long listening sessions. Battery life as advertised.",
+        "schema:datePublished": "2024-11-05"
+      },
+      {
+        "id": "ecom:reviews/6",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/earbuds-sport" },
+        "ecom:reviewer": { "id": "ecom:customers/casey" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Perfect for my marathon training. They stay in place no matter how hard I run. Great bass too!",
+        "schema:datePublished": "2024-11-12"
+      },
+      {
+        "id": "ecom:reviews/7",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/earbuds-sport" },
+        "ecom:reviewer": { "id": "ecom:customers/jordan" },
+        "ecom:rating": 3,
+        "schema:reviewBody": "Good earbuds but the case is a bit bulky. Sound quality is solid for the price.",
+        "schema:datePublished": "2024-11-18"
+      },
+      {
+        "id": "ecom:reviews/8",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/ultrabook-15" },
+        "ecom:reviewer": { "id": "ecom:customers/taylor" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Incredibly thin and light but doesn't compromise on power. Love the keyboard feel.",
+        "schema:datePublished": "2024-10-20"
+      },
+      {
+        "id": "ecom:reviews/9",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/ultrabook-15" },
+        "ecom:reviewer": { "id": "ecom:customers/morgan" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Great laptop for development work. Fast and reliable. Could use more ports though.",
+        "schema:datePublished": "2024-11-02"
+      },
+      {
+        "id": "ecom:reviews/10",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/chef-knife-set" },
+        "ecom:reviewer": { "id": "ecom:customers/casey" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "These knives are incredibly sharp and well-balanced. Makes meal prep a joy!",
+        "schema:datePublished": "2024-11-25"
+      },
+      {
+        "id": "ecom:reviews/11",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/chef-knife-set" },
+        "ecom:reviewer": { "id": "ecom:customers/alex" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Professional quality at a reasonable price. The chef's knife alone is worth it.",
+        "schema:datePublished": "2024-12-02"
+      },
+      {
+        "id": "ecom:reviews/12",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/classic-tee" },
+        "ecom:reviewer": { "id": "ecom:customers/jordan" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Super soft and fits perfectly. Ordering more in different colors!",
+        "schema:datePublished": "2024-11-08"
+      },
+      {
+        "id": "ecom:reviews/13",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/denim-jacket" },
+        "ecom:reviewer": { "id": "ecom:customers/taylor" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Perfect vintage look but with modern comfort. Get compliments every time I wear it.",
+        "schema:datePublished": "2024-11-22"
+      },
+      {
+        "id": "ecom:reviews/14",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smart-blender" },
+        "ecom:reviewer": { "id": "ecom:customers/morgan" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Powerful blender that handles everything. The smart presets are actually useful.",
+        "schema:datePublished": "2024-12-05"
+      },
+      {
+        "id": "ecom:reviews/15",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/gaming-phone" },
+        "ecom:reviewer": { "id": "ecom:customers/casey" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Game changer for mobile gaming! The 144Hz display and cooling system are no joke.",
+        "schema:datePublished": "2024-11-30"
+      },
+      {
+        "id": "ecom:reviews/16",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smartphone-lite" },
+        "ecom:reviewer": { "id": "ecom:customers/morgan" },
+        "ecom:rating": 4,
+        "schema:reviewBody": "Great value phone. Does everything I need without breaking the bank.",
+        "schema:datePublished": "2024-11-10"
+      },
+      {
+        "id": "ecom:reviews/17",
+        "type": "ecom:Review",
+        "ecom:product": { "id": "ecom:products/smartphone-lite" },
+        "ecom:reviewer": { "id": "ecom:customers/taylor" },
+        "ecom:rating": 5,
+        "schema:reviewBody": "Best budget phone on the market. Camera surprised me with how good it is.",
+        "schema:datePublished": "2024-12-08"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/ecommerce-seed-data/defaultContext.json
+++ b/docs/examples/datasets/ecommerce-seed-data/defaultContext.json
@@ -1,0 +1,10 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "schema": "http://schema.org/",
+  "ecom": "https://ecommerce-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/ecommerce/introduction.mdx
+++ b/docs/examples/datasets/ecommerce/introduction.mdx
@@ -1,0 +1,114 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# E-Commerce Product Catalog
+
+This example demonstrates how to model and query a product catalog using Fluree's graph database capabilities. You'll learn how to represent hierarchical categories, products with variants, and customer reviews—common patterns in any e-commerce application.
+
+## The Scenario
+
+Alex is building an online store and needs to:
+
+- Organize products into hierarchical categories (e.g., Electronics → Phones → Smartphones)
+- Support product variants (different sizes, colors, storage options)
+- Allow customers to leave reviews
+- Search and filter products efficiently
+
+Graph databases excel at these tasks because relationships between entities (product → category → parent category) are first-class citizens, making traversals fast and queries intuitive.
+
+## Schema Overview
+
+The catalog consists of five main entity types connected through relationships:
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    p(Product) -->|category| c(Category)
+    c -->|parentCategory| pc(Category)
+    p -->|brand| b(Brand)
+    p -->|variants| v(ProductVariant)
+    r(Review) -->|product| p
+    r -->|reviewer| cust(Customer)
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Category** | Hierarchical product categories with optional parent |
+| **Brand** | Manufacturers or brand names |
+| **Product** | Main product with base info, linked to category and brand |
+| **ProductVariant** | Specific SKU with color, size, storage, price, stock |
+| **Customer** | Registered user who can leave reviews |
+| **Review** | Rating and text feedback linked to product and customer |
+
+## Example Product
+
+Here's how a product is represented in the catalog:
+
+```json
+{
+  "id": "ecom:products/smartphone-pro-x",
+  "type": "ecom:Product",
+  "schema:name": "SmartPhone Pro X",
+  "schema:description": "Flagship smartphone with advanced camera system...",
+  "schema:sku": "SPX-001",
+  "ecom:category": { "id": "ecom:categories/electronics/phones/smartphones" },
+  "ecom:brand": { "id": "ecom:brands/techpro" },
+  "ecom:basePrice": 999.99,
+  "ecom:variants": [
+    {
+      "id": "ecom:variants/spx-128-black",
+      "type": "ecom:ProductVariant",
+      "ecom:color": "Midnight Black",
+      "ecom:storage": "128GB",
+      "ecom:price": 999.99,
+      "ecom:stockQuantity": 45,
+      "schema:sku": "SPX-128-BLK"
+    }
+  ]
+}
+```
+
+Key observations:
+
+- **Linked data**: The product references its category and brand by ID, enabling graph traversal
+- **Embedded variants**: Product variants are nested within the product
+- **Mixed vocabularies**: We use `schema:` (schema.org) for standard fields and `ecom:` for domain-specific ones
+
+## Category Hierarchy
+
+Categories form a tree structure through the `parentCategory` relationship:
+
+```
+Electronics
+├── Phones
+│   └── Smartphones
+├── Laptops
+└── Audio
+
+Clothing
+├── Men's Clothing
+└── Women's Clothing
+
+Home & Garden
+└── Kitchen
+```
+
+This structure enables powerful queries like "find all products in Electronics and its subcategories."
+
+## What You'll Learn
+
+In the following pages, you'll explore:
+
+1. **[Querying](../querying/)** - Browse products, filter by category, search by price, and calculate average ratings
+2. **[Transactions](../transactions/)** - Add new products, update inventory, and manage reviews
+
+<Admonition type="tip">
+  The hierarchical category structure and graph relationships make this dataset perfect for understanding how Fluree handles real-world e-commerce patterns.
+</Admonition>

--- a/docs/examples/datasets/ecommerce/querying.mdx
+++ b/docs/examples/datasets/ecommerce/querying.mdx
@@ -1,0 +1,236 @@
+---
+title: Querying the Catalog
+---
+
+import Admonition from "@theme/Admonition";
+
+# Querying the E-Commerce Catalog
+
+In this walkthrough, we'll explore the product catalog using progressively complex queries. You'll learn how to traverse the graph, filter results, and aggregate data.
+
+## Alex Browses the Store
+
+Alex wants to find a new smartphone. Let's help them navigate the catalog.
+
+### List All Products
+
+Start with a simple query to see what products are available:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": { "?product": ["*"] },
+  "where": { "@id": "?product", "@type": "ecom:Product" }
+}
+```
+
+This returns all products with their properties. But Alex wants to see products organized by category.
+
+### Products with Category Info
+
+Let's include the category name by traversing the graph:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name", "ecom:basePrice"],
+    "?categoryName": []
+  },
+  "where": [
+    { "@id": "?product", "@type": "ecom:Product", "ecom:category": "?category" },
+    { "@id": "?category", "schema:name": "?categoryName" }
+  ]
+}
+```
+
+Now we see each product with its category name. The `where` clause traverses from product → category → name.
+
+### Filter by Category
+
+Alex only wants smartphones. We can filter using `values`:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name", "schema:description", "ecom:basePrice"]
+  },
+  "where": { "@id": "?product", "@type": "ecom:Product", "ecom:category": "?category" },
+  "values": [
+    ["?category"],
+    [{"@id": "ecom:categories/electronics/phones/smartphones"}]
+  ]
+}
+```
+
+This returns only products in the Smartphones category: SmartPhone Pro X, SmartPhone Lite, and GamePhone Ultra.
+
+### Filter by Price Range
+
+Alex has a budget. Let's find smartphones under $800:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name", "ecom:basePrice"]
+  },
+  "where": [
+    { "@id": "?product", "@type": "ecom:Product", "ecom:category": {"@id": "ecom:categories/electronics/phones/smartphones"}, "ecom:basePrice": "?price" },
+    ["filter", "(< ?price 800)"]
+  ]
+}
+```
+
+Result: SmartPhone Lite ($499.99) and GamePhone Ultra ($799.99).
+
+<Admonition type="info">
+  The `filter` clause uses comparison operators like `<`, `>`, `<=`, `>=`, and `=` to constrain numeric values.
+</Admonition>
+
+### Find In-Stock Variants
+
+Alex wants to see available variants. Let's find variants with stock > 0:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name"],
+    "?variant": ["ecom:color", "ecom:storage", "ecom:price", "ecom:stockQuantity"]
+  },
+  "where": [
+    { "@id": "?product", "@type": "ecom:Product", "ecom:variants": "?variant" },
+    { "@id": "?variant", "ecom:stockQuantity": "?stock" },
+    ["filter", "(> ?stock 0)"]
+  ]
+}
+```
+
+This traverses product → variants and filters out any with zero stock (like the Racing Red SportBuds).
+
+### Category Hierarchy Traversal
+
+One of the most powerful graph features is traversing hierarchies. Let's find all products in "Electronics" including subcategories:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name"],
+    "?categoryName": []
+  },
+  "where": [
+    { "@id": "?product", "@type": "ecom:Product", "ecom:category": "?leafCategory" },
+    { "@id": "?leafCategory", "ecom:parentCategory*": {"@id": "ecom:categories/electronics"}, "schema:name": "?categoryName" }
+  ]
+}
+```
+
+The `*` modifier on `parentCategory*` enables transitive traversal—it follows the parent chain up to the Electronics category. This returns all phones, laptops, and audio products.
+
+### Get Product Reviews
+
+Let's see what customers think about a specific product:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?review": ["ecom:rating", "schema:reviewBody", "schema:datePublished"],
+    "?reviewerName": []
+  },
+  "where": [
+    { "@id": "?review", "@type": "ecom:Review", "ecom:product": {"@id": "ecom:products/smartphone-pro-x"}, "ecom:reviewer": "?reviewer" },
+    { "@id": "?reviewer", "schema:givenName": "?reviewerName" }
+  ],
+  "orderBy": [{"desc": "?rating"}]
+}
+```
+
+This query:
+1. Finds reviews for the SmartPhone Pro X
+2. Traverses to the reviewer to get their name
+3. Orders by rating (highest first)
+
+### Calculate Average Rating
+
+Let's aggregate ratings to find the average:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?productName", "(avg ?rating)"],
+  "where": [
+    { "@id": "?review", "@type": "ecom:Review", "ecom:product": "?product", "ecom:rating": "?rating" },
+    { "@id": "?product", "schema:name": "?productName" }
+  ],
+  "groupBy": "?productName",
+  "orderBy": [{"desc": "(avg ?rating)"}]
+}
+```
+
+This groups reviews by product and calculates the average rating, sorted from highest to lowest. Great for finding top-rated products!
+
+### Find Products by Brand
+
+Alex prefers TechPro products. Let's filter by brand:
+
+```json
+{
+  "@context": {
+    "ecom": "https://ecommerce-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?product": ["schema:name", "schema:description", "ecom:basePrice"]
+  },
+  "where": [
+    { "@id": "?product", "@type": "ecom:Product", "ecom:brand": "?brand" },
+    { "@id": "?brand", "schema:name": "TechPro" }
+  ]
+}
+```
+
+Returns SmartPhone Pro X and SmartPhone Lite—all TechPro products.
+
+## Summary
+
+In this walkthrough, you learned how to:
+
+| Technique | Example |
+|-----------|---------|
+| **Basic selection** | `select: { "?product": ["*"] }` |
+| **Graph traversal** | Product → Category → Name |
+| **Filtering with values** | Constrain to specific category |
+| **Numeric filters** | Price < 800 |
+| **Transitive traversal** | `parentCategory*` for hierarchy |
+| **Aggregation** | `(avg ?rating)` with `groupBy` |
+| **Ordering** | `orderBy: [{"desc": "?rating"}]` |
+
+Next, learn how to [add and update data](../transactions/) in the catalog.

--- a/docs/examples/datasets/ecommerce/transactions.mdx
+++ b/docs/examples/datasets/ecommerce/transactions.mdx
@@ -1,0 +1,275 @@
+---
+title: Transactions
+---
+
+import Admonition from "@theme/Admonition";
+
+# Managing Catalog Data
+
+This page demonstrates how to add, update, and delete data in the e-commerce catalog. You'll learn transaction patterns for common operations like adding products, updating inventory, and managing reviews.
+
+## Adding a New Product
+
+To add a new product with variants, use an insert transaction:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "insert": [
+    {
+      "id": "ecom:products/wireless-charger",
+      "type": "ecom:Product",
+      "schema:name": "FastCharge Wireless Pad",
+      "schema:description": "15W fast wireless charging pad compatible with all Qi devices.",
+      "schema:sku": "FWP-001",
+      "ecom:category": { "id": "ecom:categories/electronics" },
+      "ecom:brand": { "id": "ecom:brands/techpro" },
+      "ecom:basePrice": 49.99,
+      "ecom:variants": [
+        {
+          "id": "ecom:variants/fwp-black",
+          "type": "ecom:ProductVariant",
+          "ecom:color": "Black",
+          "ecom:price": 49.99,
+          "ecom:stockQuantity": 100,
+          "schema:sku": "FWP-BLK"
+        },
+        {
+          "id": "ecom:variants/fwp-white",
+          "type": "ecom:ProductVariant",
+          "ecom:color": "White",
+          "ecom:price": 49.99,
+          "ecom:stockQuantity": 75,
+          "schema:sku": "FWP-WHT"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The product and its variants are created in a single transaction, maintaining data consistency.
+
+## Adding a New Category
+
+Extend the category hierarchy by adding a new subcategory:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "insert": {
+    "id": "ecom:categories/electronics/accessories",
+    "type": "ecom:Category",
+    "schema:name": "Accessories",
+    "schema:description": "Phone cases, chargers, cables, and more",
+    "ecom:parentCategory": { "id": "ecom:categories/electronics" }
+  }
+}
+```
+
+Now you can assign products to this new category.
+
+## Updating Inventory
+
+When a sale occurs, decrement the stock quantity. Use `delete` + `insert` for updates:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": {
+    "id": "ecom:variants/spx-128-black",
+    "ecom:stockQuantity": 45
+  },
+  "insert": {
+    "id": "ecom:variants/spx-128-black",
+    "ecom:stockQuantity": 44
+  }
+}
+```
+
+<Admonition type="info">
+  In Fluree, updates are performed by deleting the old value and inserting the new one. This maintains a complete history of all changes.
+</Admonition>
+
+## Bulk Inventory Update
+
+Update multiple variants at once:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": [
+    { "id": "ecom:variants/spx-128-black", "ecom:stockQuantity": 45 },
+    { "id": "ecom:variants/spx-256-black", "ecom:stockQuantity": 32 }
+  ],
+  "insert": [
+    { "id": "ecom:variants/spx-128-black", "ecom:stockQuantity": 50 },
+    { "id": "ecom:variants/spx-256-black", "ecom:stockQuantity": 40 }
+  ]
+}
+```
+
+## Adding a Customer Review
+
+When a customer submits a review:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "insert": {
+    "id": "ecom:reviews/18",
+    "type": "ecom:Review",
+    "ecom:product": { "id": "ecom:products/wireless-charger" },
+    "ecom:reviewer": { "id": "ecom:customers/alex" },
+    "ecom:rating": 5,
+    "schema:reviewBody": "Charges my phone super fast! Love the minimalist design.",
+    "schema:datePublished": "2024-12-10"
+  }
+}
+```
+
+## Updating a Review
+
+If a customer edits their review:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": {
+    "id": "ecom:reviews/18",
+    "ecom:rating": 5,
+    "schema:reviewBody": "Charges my phone super fast! Love the minimalist design."
+  },
+  "insert": {
+    "id": "ecom:reviews/18",
+    "ecom:rating": 4,
+    "schema:reviewBody": "Charges fast but gets a bit warm. Still recommend it."
+  }
+}
+```
+
+## Updating Product Price
+
+Change the base price and variant prices:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": [
+    { "id": "ecom:products/smartphone-lite", "ecom:basePrice": 499.99 },
+    { "id": "ecom:variants/spl-64-blue", "ecom:price": 499.99 },
+    { "id": "ecom:variants/spl-128-blue", "ecom:price": 549.99 }
+  ],
+  "insert": [
+    { "id": "ecom:products/smartphone-lite", "ecom:basePrice": 449.99 },
+    { "id": "ecom:variants/spl-64-blue", "ecom:price": 449.99 },
+    { "id": "ecom:variants/spl-128-blue", "ecom:price": 499.99 }
+  ]
+}
+```
+
+## Deleting a Product
+
+Remove a discontinued product and its variants:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": [
+    {
+      "id": "ecom:products/discontinued-item",
+      "schema:name": null,
+      "schema:description": null,
+      "schema:sku": null,
+      "ecom:category": null,
+      "ecom:brand": null,
+      "ecom:basePrice": null,
+      "ecom:variants": null
+    }
+  ]
+}
+```
+
+Using `null` as the value deletes all values for that property.
+
+<Admonition type="warning">
+  Deleting a product doesn't automatically delete its reviews. Depending on your application logic, you may want to keep reviews for historical purposes or delete them separately.
+</Admonition>
+
+## Moving a Product to a Different Category
+
+Recategorize a product:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "delete": {
+    "id": "ecom:products/wireless-charger",
+    "ecom:category": { "id": "ecom:categories/electronics" }
+  },
+  "insert": {
+    "id": "ecom:products/wireless-charger",
+    "ecom:category": { "id": "ecom:categories/electronics/accessories" }
+  }
+}
+```
+
+## Registering a New Customer
+
+Add a new customer who can then leave reviews:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "ecom": "https://ecommerce-example.com/ns/"
+  },
+  "insert": {
+    "id": "ecom:customers/sam",
+    "type": "ecom:Customer",
+    "schema:givenName": "Sam",
+    "schema:familyName": "Rivera",
+    "schema:email": "sam.rivera@example.com"
+  }
+}
+```
+
+## Summary
+
+Common transaction patterns:
+
+| Operation | Pattern |
+|-----------|---------|
+| **Create** | `insert: { ... }` |
+| **Update** | `delete: { old }` + `insert: { new }` |
+| **Delete property** | `delete: { "id": "...", "prop": null }` |
+| **Bulk operations** | Use arrays: `insert: [...]` |
+
+All transactions in Fluree are immutable—the previous state is preserved in history, enabling time-travel queries and audit trails.

--- a/docs/examples/datasets/healthcare-seed-data/01_data.json
+++ b/docs/examples/datasets/healthcare-seed-data/01_data.json
@@ -1,0 +1,60 @@
+[
+  {
+    "@id": "clinic-records",
+    "@graph": [
+      {
+        "id": "health:facilities/downtown-clinic",
+        "type": "health:Facility",
+        "schema:name": "Downtown Medical Clinic",
+        "schema:address": "123 Main St"
+      },
+      {
+        "id": "health:providers/dr-smith",
+        "type": "health:Provider",
+        "schema:name": "Dr. Sarah Smith",
+        "health:specialty": "Internal Medicine",
+        "health:facility": { "id": "health:facilities/downtown-clinic" }
+      },
+      {
+        "id": "health:providers/dr-jones",
+        "type": "health:Provider",
+        "schema:name": "Dr. Michael Jones",
+        "health:specialty": "Cardiology",
+        "health:facility": { "id": "health:facilities/downtown-clinic" }
+      },
+      {
+        "id": "health:patients/p001",
+        "type": "health:Patient",
+        "schema:givenName": "John",
+        "schema:familyName": "Doe",
+        "health:dateOfBirth": "1985-03-15",
+        "health:primaryProvider": { "id": "health:providers/dr-smith" }
+      },
+      {
+        "id": "health:patients/p002",
+        "type": "health:Patient",
+        "schema:givenName": "Jane",
+        "schema:familyName": "Wilson",
+        "health:dateOfBirth": "1990-07-22",
+        "health:primaryProvider": { "id": "health:providers/dr-jones" }
+      },
+      {
+        "id": "health:appointments/a001",
+        "type": "health:Appointment",
+        "health:patient": { "id": "health:patients/p001" },
+        "health:provider": { "id": "health:providers/dr-smith" },
+        "health:date": "2024-03-15",
+        "health:reason": "Annual checkup"
+      },
+      {
+        "id": "health:diagnoses/d001",
+        "type": "health:Diagnosis",
+        "health:patient": { "id": "health:patients/p001" },
+        "health:provider": { "id": "health:providers/dr-smith" },
+        "health:icdCode": "I10",
+        "health:description": "Essential hypertension",
+        "health:date": "2024-03-15"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/healthcare-seed-data/defaultContext.json
+++ b/docs/examples/datasets/healthcare-seed-data/defaultContext.json
@@ -1,0 +1,7 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "schema": "http://schema.org/",
+  "health": "https://healthcare-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/healthcare/introduction.mdx
+++ b/docs/examples/datasets/healthcare/introduction.mdx
@@ -1,0 +1,37 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Healthcare Records
+
+This example demonstrates a clinic patient management system with a focus on access control—patients should only see their own records, and providers should only see their patients.
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    p(Patient) -->|primaryProvider| pr(Provider)
+    pr -->|facility| f(Facility)
+    a(Appointment) -->|patient| p
+    a -->|provider| pr
+    d(Diagnosis) -->|patient| p
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Patient** | Person receiving care |
+| **Provider** | Doctor or healthcare professional |
+| **Facility** | Clinic or hospital |
+| **Appointment** | Scheduled visit |
+| **Diagnosis** | Medical diagnosis with ICD code |
+
+<Admonition type="warning">
+  Healthcare data requires strict access control. This example demonstrates HIPAA-style restrictions using Fluree policies.
+</Admonition>

--- a/docs/examples/datasets/healthcare/policies.mdx
+++ b/docs/examples/datasets/healthcare/policies.mdx
@@ -1,0 +1,57 @@
+---
+title: Access Control Policies
+---
+
+# Healthcare Access Control
+
+## Patient Self-Access Policy
+
+Patients can only see their own records:
+
+```json
+{
+  "@id": "health:policies/patient-self-access",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "health:Diagnosis" },
+  "f:allow": [{
+    "f:targetRole": { "@id": "health:roles/patient" },
+    "f:action": [{ "@id": "f:view" }],
+    "f:where": {
+      "@type": "@json",
+      "@value": { "@id": "?$this", "health:patient": "?$identity" }
+    }
+  }]
+}
+```
+
+## Provider Access Policy
+
+Providers can see records for their patients:
+
+```json
+{
+  "@id": "health:policies/provider-patient-access",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "health:Patient" },
+  "f:allow": [{
+    "f:targetRole": { "@id": "health:roles/provider" },
+    "f:action": [{ "@id": "f:view" }],
+    "f:where": {
+      "@type": "@json",
+      "@value": { "@id": "?$this", "health:primaryProvider": "?$identity" }
+    }
+  }]
+}
+```
+
+## Testing Access
+
+Query as a patient (should only see own records):
+
+```json
+{
+  "select": { "?diagnosis": ["*"] },
+  "where": { "@id": "?diagnosis", "@type": "health:Diagnosis" },
+  "opts": { "identity": { "@id": "health:patients/p001" } }
+}
+```

--- a/docs/examples/datasets/healthcare/querying.mdx
+++ b/docs/examples/datasets/healthcare/querying.mdx
@@ -1,0 +1,49 @@
+---
+title: Querying
+---
+
+# Querying Healthcare Records
+
+## Patient History
+
+Get a patient's complete history:
+
+```json
+{
+  "@context": { "schema": "http://schema.org/", "health": "https://healthcare-example.com/ns/" },
+  "select": {
+    "?patient": ["schema:givenName", "schema:familyName"],
+    "?diagnosis": ["health:description", "health:date"]
+  },
+  "where": [
+    { "@id": "health:patients/p001" },
+    { "@id": "?diagnosis", "health:patient": {"@id": "health:patients/p001"} }
+  ]
+}
+```
+
+## Provider's Patients
+
+```json
+{
+  "select": { "?patient": ["schema:givenName", "schema:familyName"] },
+  "where": { "@id": "?patient", "health:primaryProvider": {"@id": "health:providers/dr-smith"} }
+}
+```
+
+## Upcoming Appointments
+
+```json
+{
+  "select": {
+    "?appt": ["health:date", "health:reason"],
+    "?patientName": []
+  },
+  "where": [
+    { "@id": "?appt", "@type": "health:Appointment", "health:patient": "?patient", "health:date": "?date" },
+    { "@id": "?patient", "schema:givenName": "?patientName" },
+    ["filter", "(>= ?date \"2024-03-01\")"]
+  ],
+  "orderBy": "?date"
+}
+```

--- a/docs/examples/datasets/knowledge-base-seed-data/01_data.json
+++ b/docs/examples/datasets/knowledge-base-seed-data/01_data.json
@@ -1,0 +1,81 @@
+[
+  {
+    "@id": "company-wiki",
+    "@graph": [
+      {
+        "id": "wiki:authors/alice",
+        "type": "wiki:Author",
+        "schema:name": "Alice Chen",
+        "schema:email": "alice@company.com"
+      },
+      {
+        "id": "wiki:authors/bob",
+        "type": "wiki:Author",
+        "schema:name": "Bob Smith",
+        "schema:email": "bob@company.com"
+      },
+      {
+        "id": "wiki:tags/onboarding",
+        "type": "wiki:Tag",
+        "schema:name": "onboarding"
+      },
+      {
+        "id": "wiki:tags/engineering",
+        "type": "wiki:Tag",
+        "schema:name": "engineering"
+      },
+      {
+        "id": "wiki:tags/hr",
+        "type": "wiki:Tag",
+        "schema:name": "hr"
+      },
+      {
+        "id": "wiki:tags/architecture",
+        "type": "wiki:Tag",
+        "schema:name": "architecture"
+      },
+      {
+        "id": "wiki:articles/welcome",
+        "type": "wiki:Article",
+        "schema:name": "Welcome to the Company",
+        "wiki:content": "Welcome to our team! This guide will help you get started...",
+        "wiki:author": { "id": "wiki:authors/alice" },
+        "wiki:tags": [{ "id": "wiki:tags/onboarding" }, { "id": "wiki:tags/hr" }],
+        "wiki:createdAt": "2024-01-15",
+        "wiki:modifiedAt": "2024-02-10"
+      },
+      {
+        "id": "wiki:articles/dev-setup",
+        "type": "wiki:Article",
+        "schema:name": "Developer Environment Setup",
+        "wiki:content": "Follow these steps to set up your development environment...",
+        "wiki:author": { "id": "wiki:authors/bob" },
+        "wiki:tags": [{ "id": "wiki:tags/onboarding" }, { "id": "wiki:tags/engineering" }],
+        "wiki:cites": [{ "id": "wiki:articles/welcome" }],
+        "wiki:createdAt": "2024-01-20",
+        "wiki:modifiedAt": "2024-03-05"
+      },
+      {
+        "id": "wiki:articles/api-guide",
+        "type": "wiki:Article",
+        "schema:name": "API Design Guidelines",
+        "wiki:content": "Our API follows RESTful conventions with these standards...",
+        "wiki:author": { "id": "wiki:authors/bob" },
+        "wiki:tags": [{ "id": "wiki:tags/engineering" }, { "id": "wiki:tags/architecture" }],
+        "wiki:createdAt": "2024-02-01",
+        "wiki:modifiedAt": "2024-02-01"
+      },
+      {
+        "id": "wiki:articles/microservices",
+        "type": "wiki:Article",
+        "schema:name": "Microservices Architecture",
+        "wiki:content": "Our system uses a microservices architecture...",
+        "wiki:author": { "id": "wiki:authors/alice" },
+        "wiki:tags": [{ "id": "wiki:tags/architecture" }, { "id": "wiki:tags/engineering" }],
+        "wiki:cites": [{ "id": "wiki:articles/api-guide" }],
+        "wiki:createdAt": "2024-02-15",
+        "wiki:modifiedAt": "2024-03-01"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/knowledge-base-seed-data/defaultContext.json
+++ b/docs/examples/datasets/knowledge-base-seed-data/defaultContext.json
@@ -1,0 +1,8 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "schema": "http://schema.org/",
+  "wiki": "https://wiki-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/knowledge-base/history.mdx
+++ b/docs/examples/datasets/knowledge-base/history.mdx
@@ -1,0 +1,51 @@
+---
+title: History & Time-Travel
+---
+
+# History & Time-Travel Queries
+
+Fluree maintains a complete history of all changes, enabling powerful temporal queries.
+
+## Article History
+
+See all versions of an article:
+
+```json
+{
+  "@context": { "f": "https://ns.flur.ee/ledger#", "wiki": "https://wiki-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?article": ["schema:name", "wiki:content", "wiki:modifiedAt"] },
+  "where": { "@id": "wiki:articles/dev-setup" },
+  "opts": {
+    "history": true
+  }
+}
+```
+
+## Point-in-Time Query
+
+See the wiki as it was on a specific date:
+
+```json
+{
+  "select": { "?article": ["schema:name"] },
+  "where": { "@id": "?article", "@type": "wiki:Article" },
+  "opts": {
+    "t": "2024-01-20"
+  }
+}
+```
+
+## Change Log
+
+Track who modified what:
+
+```json
+{
+  "history": {"@id": "wiki:articles/dev-setup"},
+  "opts": {
+    "showAssertions": true
+  }
+}
+```
+
+This returns the complete change history with timestamps and assertions/retractions.

--- a/docs/examples/datasets/knowledge-base/introduction.mdx
+++ b/docs/examples/datasets/knowledge-base/introduction.mdx
@@ -1,0 +1,40 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Knowledge Base / Wiki
+
+This example demonstrates a company wiki with articles, tags, citations, and version history—showcasing Fluree's temporal query capabilities.
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    a(Article) -->|author| auth(Author)
+    a -->|tags| t(Tag)
+    a -->|cites| a2(Article)
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Article** | Wiki page with content, timestamps |
+| **Author** | Person who wrote the article |
+| **Tag** | Category labels for articles |
+| **Citation** | Article-to-article references |
+
+## Key Features
+
+- **Citations**: Articles can reference other articles, creating a knowledge graph
+- **Version History**: All changes are tracked with timestamps
+- **Time-Travel**: Query the wiki as it existed at any point in time
+
+<Admonition type="info">
+  The citation graph enables powerful queries like "find all articles that cite this one" or "show the citation chain."
+</Admonition>

--- a/docs/examples/datasets/knowledge-base/querying.mdx
+++ b/docs/examples/datasets/knowledge-base/querying.mdx
@@ -1,0 +1,48 @@
+---
+title: Querying
+---
+
+# Querying the Knowledge Base
+
+## Find Articles by Tag
+
+```json
+{
+  "@context": { "wiki": "https://wiki-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?article": ["schema:name", "wiki:author"] },
+  "where": { "@id": "?article", "wiki:tags": {"@id": "wiki:tags/engineering"} }
+}
+```
+
+## Citation Graph
+
+Find what an article cites:
+
+```json
+{
+  "@context": { "wiki": "https://wiki-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?cited": ["schema:name"] },
+  "where": { "@id": "wiki:articles/microservices", "wiki:cites": "?cited" }
+}
+```
+
+Find articles citing a specific article:
+
+```json
+{
+  "@context": { "wiki": "https://wiki-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?article": ["schema:name"] },
+  "where": { "@id": "?article", "wiki:cites": {"@id": "wiki:articles/api-guide"} }
+}
+```
+
+## Articles by Author
+
+```json
+{
+  "@context": { "wiki": "https://wiki-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?article": ["schema:name", "wiki:createdAt"] },
+  "where": { "@id": "?article", "wiki:author": {"@id": "wiki:authors/bob"} },
+  "orderBy": [{"desc": "?createdAt"}]
+}
+```

--- a/docs/examples/datasets/org-chart-seed-data/01_departments.json
+++ b/docs/examples/datasets/org-chart-seed-data/01_departments.json
@@ -1,0 +1,51 @@
+[
+  {
+    "@id": "acme-corp",
+    "@graph": [
+      {
+        "id": "org:departments/executive",
+        "type": "org:Department",
+        "schema:name": "Executive",
+        "schema:description": "Executive leadership team"
+      },
+      {
+        "id": "org:departments/engineering",
+        "type": "org:Department",
+        "schema:name": "Engineering",
+        "schema:description": "Product development and technical operations"
+      },
+      {
+        "id": "org:departments/engineering/platform",
+        "type": "org:Department",
+        "schema:name": "Platform Team",
+        "schema:description": "Core infrastructure and platform services",
+        "org:parentDepartment": { "id": "org:departments/engineering" }
+      },
+      {
+        "id": "org:departments/engineering/product",
+        "type": "org:Department",
+        "schema:name": "Product Team",
+        "schema:description": "User-facing product development",
+        "org:parentDepartment": { "id": "org:departments/engineering" }
+      },
+      {
+        "id": "org:departments/sales",
+        "type": "org:Department",
+        "schema:name": "Sales",
+        "schema:description": "Revenue generation and customer acquisition"
+      },
+      {
+        "id": "org:departments/marketing",
+        "type": "org:Department",
+        "schema:name": "Marketing",
+        "schema:description": "Brand, content, and demand generation"
+      },
+      {
+        "id": "org:departments/hr",
+        "type": "org:Department",
+        "schema:name": "Human Resources",
+        "schema:description": "People operations and culture"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/org-chart-seed-data/02_people.json
+++ b/docs/examples/datasets/org-chart-seed-data/02_people.json
@@ -1,0 +1,215 @@
+[
+  {
+    "@id": "acme-corp",
+    "@graph": [
+      {
+        "id": "org:people/sarah-chen",
+        "type": "org:Person",
+        "schema:givenName": "Sarah",
+        "schema:familyName": "Chen",
+        "schema:email": "sarah.chen@acme.com",
+        "org:title": "CEO",
+        "org:department": { "id": "org:departments/executive" },
+        "org:hireDate": "2018-03-15"
+      },
+      {
+        "id": "org:people/marcus-johnson",
+        "type": "org:Person",
+        "schema:givenName": "Marcus",
+        "schema:familyName": "Johnson",
+        "schema:email": "marcus.johnson@acme.com",
+        "org:title": "CTO",
+        "org:department": { "id": "org:departments/engineering" },
+        "org:reportsTo": { "id": "org:people/sarah-chen" },
+        "org:hireDate": "2018-06-01"
+      },
+      {
+        "id": "org:people/lisa-wong",
+        "type": "org:Person",
+        "schema:givenName": "Lisa",
+        "schema:familyName": "Wong",
+        "schema:email": "lisa.wong@acme.com",
+        "org:title": "VP of Sales",
+        "org:department": { "id": "org:departments/sales" },
+        "org:reportsTo": { "id": "org:people/sarah-chen" },
+        "org:hireDate": "2019-01-10"
+      },
+      {
+        "id": "org:people/david-kim",
+        "type": "org:Person",
+        "schema:givenName": "David",
+        "schema:familyName": "Kim",
+        "schema:email": "david.kim@acme.com",
+        "org:title": "VP of Marketing",
+        "org:department": { "id": "org:departments/marketing" },
+        "org:reportsTo": { "id": "org:people/sarah-chen" },
+        "org:hireDate": "2019-04-22"
+      },
+      {
+        "id": "org:people/rachel-green",
+        "type": "org:Person",
+        "schema:givenName": "Rachel",
+        "schema:familyName": "Green",
+        "schema:email": "rachel.green@acme.com",
+        "org:title": "HR Director",
+        "org:department": { "id": "org:departments/hr" },
+        "org:reportsTo": { "id": "org:people/sarah-chen" },
+        "org:hireDate": "2019-08-05"
+      },
+      {
+        "id": "org:people/alex-rivera",
+        "type": "org:Person",
+        "schema:givenName": "Alex",
+        "schema:familyName": "Rivera",
+        "schema:email": "alex.rivera@acme.com",
+        "org:title": "Platform Lead",
+        "org:department": { "id": "org:departments/engineering/platform" },
+        "org:reportsTo": { "id": "org:people/marcus-johnson" },
+        "org:hireDate": "2019-11-18"
+      },
+      {
+        "id": "org:people/jordan-patel",
+        "type": "org:Person",
+        "schema:givenName": "Jordan",
+        "schema:familyName": "Patel",
+        "schema:email": "jordan.patel@acme.com",
+        "org:title": "Product Lead",
+        "org:department": { "id": "org:departments/engineering/product" },
+        "org:reportsTo": { "id": "org:people/marcus-johnson" },
+        "org:hireDate": "2020-02-03"
+      },
+      {
+        "id": "org:people/emma-wilson",
+        "type": "org:Person",
+        "schema:givenName": "Emma",
+        "schema:familyName": "Wilson",
+        "schema:email": "emma.wilson@acme.com",
+        "org:title": "Senior Platform Engineer",
+        "org:department": { "id": "org:departments/engineering/platform" },
+        "org:reportsTo": { "id": "org:people/alex-rivera" },
+        "org:hireDate": "2020-05-11"
+      },
+      {
+        "id": "org:people/michael-brown",
+        "type": "org:Person",
+        "schema:givenName": "Michael",
+        "schema:familyName": "Brown",
+        "schema:email": "michael.brown@acme.com",
+        "org:title": "Platform Engineer",
+        "org:department": { "id": "org:departments/engineering/platform" },
+        "org:reportsTo": { "id": "org:people/alex-rivera" },
+        "org:hireDate": "2021-01-25"
+      },
+      {
+        "id": "org:people/sophia-martinez",
+        "type": "org:Person",
+        "schema:givenName": "Sophia",
+        "schema:familyName": "Martinez",
+        "schema:email": "sophia.martinez@acme.com",
+        "org:title": "Platform Engineer",
+        "org:department": { "id": "org:departments/engineering/platform" },
+        "org:reportsTo": { "id": "org:people/alex-rivera" },
+        "org:hireDate": "2021-06-14"
+      },
+      {
+        "id": "org:people/james-taylor",
+        "type": "org:Person",
+        "schema:givenName": "James",
+        "schema:familyName": "Taylor",
+        "schema:email": "james.taylor@acme.com",
+        "org:title": "Senior Product Engineer",
+        "org:department": { "id": "org:departments/engineering/product" },
+        "org:reportsTo": { "id": "org:people/jordan-patel" },
+        "org:hireDate": "2020-08-17"
+      },
+      {
+        "id": "org:people/olivia-garcia",
+        "type": "org:Person",
+        "schema:givenName": "Olivia",
+        "schema:familyName": "Garcia",
+        "schema:email": "olivia.garcia@acme.com",
+        "org:title": "Product Engineer",
+        "org:department": { "id": "org:departments/engineering/product" },
+        "org:reportsTo": { "id": "org:people/jordan-patel" },
+        "org:hireDate": "2021-03-29"
+      },
+      {
+        "id": "org:people/william-anderson",
+        "type": "org:Person",
+        "schema:givenName": "William",
+        "schema:familyName": "Anderson",
+        "schema:email": "william.anderson@acme.com",
+        "org:title": "Product Engineer",
+        "org:department": { "id": "org:departments/engineering/product" },
+        "org:reportsTo": { "id": "org:people/jordan-patel" },
+        "org:hireDate": "2022-01-10"
+      },
+      {
+        "id": "org:people/ava-thomas",
+        "type": "org:Person",
+        "schema:givenName": "Ava",
+        "schema:familyName": "Thomas",
+        "schema:email": "ava.thomas@acme.com",
+        "org:title": "Sales Manager",
+        "org:department": { "id": "org:departments/sales" },
+        "org:reportsTo": { "id": "org:people/lisa-wong" },
+        "org:hireDate": "2020-04-06"
+      },
+      {
+        "id": "org:people/ethan-jackson",
+        "type": "org:Person",
+        "schema:givenName": "Ethan",
+        "schema:familyName": "Jackson",
+        "schema:email": "ethan.jackson@acme.com",
+        "org:title": "Account Executive",
+        "org:department": { "id": "org:departments/sales" },
+        "org:reportsTo": { "id": "org:people/ava-thomas" },
+        "org:hireDate": "2021-02-15"
+      },
+      {
+        "id": "org:people/mia-white",
+        "type": "org:Person",
+        "schema:givenName": "Mia",
+        "schema:familyName": "White",
+        "schema:email": "mia.white@acme.com",
+        "org:title": "Account Executive",
+        "org:department": { "id": "org:departments/sales" },
+        "org:reportsTo": { "id": "org:people/ava-thomas" },
+        "org:hireDate": "2021-09-20"
+      },
+      {
+        "id": "org:people/noah-harris",
+        "type": "org:Person",
+        "schema:givenName": "Noah",
+        "schema:familyName": "Harris",
+        "schema:email": "noah.harris@acme.com",
+        "org:title": "Content Manager",
+        "org:department": { "id": "org:departments/marketing" },
+        "org:reportsTo": { "id": "org:people/david-kim" },
+        "org:hireDate": "2020-07-13"
+      },
+      {
+        "id": "org:people/isabella-clark",
+        "type": "org:Person",
+        "schema:givenName": "Isabella",
+        "schema:familyName": "Clark",
+        "schema:email": "isabella.clark@acme.com",
+        "org:title": "Marketing Specialist",
+        "org:department": { "id": "org:departments/marketing" },
+        "org:reportsTo": { "id": "org:people/noah-harris" },
+        "org:hireDate": "2021-11-08"
+      },
+      {
+        "id": "org:people/liam-lewis",
+        "type": "org:Person",
+        "schema:givenName": "Liam",
+        "schema:familyName": "Lewis",
+        "schema:email": "liam.lewis@acme.com",
+        "org:title": "HR Coordinator",
+        "org:department": { "id": "org:departments/hr" },
+        "org:reportsTo": { "id": "org:people/rachel-green" },
+        "org:hireDate": "2020-10-05"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/org-chart-seed-data/03_projects.json
+++ b/docs/examples/datasets/org-chart-seed-data/03_projects.json
@@ -1,0 +1,112 @@
+[
+  {
+    "@id": "acme-corp",
+    "@graph": [
+      {
+        "id": "org:projects/platform-v2",
+        "type": "org:Project",
+        "schema:name": "Platform v2.0",
+        "schema:description": "Major platform infrastructure upgrade",
+        "org:status": "active",
+        "org:startDate": "2024-01-15",
+        "org:lead": { "id": "org:people/alex-rivera" },
+        "org:members": [
+          { "id": "org:people/emma-wilson" },
+          { "id": "org:people/michael-brown" },
+          { "id": "org:people/sophia-martinez" }
+        ]
+      },
+      {
+        "id": "org:projects/mobile-app",
+        "type": "org:Project",
+        "schema:name": "Mobile App Launch",
+        "schema:description": "Native mobile application development",
+        "org:status": "active",
+        "org:startDate": "2024-03-01",
+        "org:lead": { "id": "org:people/jordan-patel" },
+        "org:members": [
+          { "id": "org:people/james-taylor" },
+          { "id": "org:people/olivia-garcia" },
+          { "id": "org:people/william-anderson" }
+        ]
+      },
+      {
+        "id": "org:projects/enterprise-sales",
+        "type": "org:Project",
+        "schema:name": "Enterprise Sales Initiative",
+        "schema:description": "Expanding into enterprise market segment",
+        "org:status": "active",
+        "org:startDate": "2024-02-01",
+        "org:lead": { "id": "org:people/ava-thomas" },
+        "org:members": [
+          { "id": "org:people/ethan-jackson" },
+          { "id": "org:people/mia-white" }
+        ]
+      },
+      {
+        "id": "org:projects/brand-refresh",
+        "type": "org:Project",
+        "schema:name": "Brand Refresh 2024",
+        "schema:description": "Company-wide brand identity update",
+        "org:status": "completed",
+        "org:startDate": "2023-09-01",
+        "org:endDate": "2024-01-31",
+        "org:lead": { "id": "org:people/noah-harris" },
+        "org:members": [
+          { "id": "org:people/isabella-clark" }
+        ]
+      },
+      {
+        "id": "org:projects/hiring-2024",
+        "type": "org:Project",
+        "schema:name": "2024 Hiring Initiative",
+        "schema:description": "Scaling the team for growth",
+        "org:status": "active",
+        "org:startDate": "2024-01-01",
+        "org:lead": { "id": "org:people/rachel-green" },
+        "org:members": [
+          { "id": "org:people/liam-lewis" }
+        ]
+      },
+      {
+        "id": "org:projects/security-audit",
+        "type": "org:Project",
+        "schema:name": "Security Audit Q1",
+        "schema:description": "Quarterly security review and improvements",
+        "org:status": "active",
+        "org:startDate": "2024-01-08",
+        "org:lead": { "id": "org:people/marcus-johnson" },
+        "org:members": [
+          { "id": "org:people/alex-rivera" },
+          { "id": "org:people/emma-wilson" }
+        ]
+      },
+      {
+        "id": "org:projects/customer-portal",
+        "type": "org:Project",
+        "schema:name": "Customer Portal Redesign",
+        "schema:description": "Improving the customer self-service experience",
+        "org:status": "planning",
+        "org:startDate": "2024-04-01",
+        "org:lead": { "id": "org:people/jordan-patel" },
+        "org:members": [
+          { "id": "org:people/james-taylor" },
+          { "id": "org:people/noah-harris" }
+        ]
+      },
+      {
+        "id": "org:projects/api-v3",
+        "type": "org:Project",
+        "schema:name": "API v3 Development",
+        "schema:description": "Next generation public API",
+        "org:status": "planning",
+        "org:startDate": "2024-05-01",
+        "org:lead": { "id": "org:people/emma-wilson" },
+        "org:members": [
+          { "id": "org:people/michael-brown" },
+          { "id": "org:people/sophia-martinez" }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/org-chart-seed-data/04_skills.json
+++ b/docs/examples/datasets/org-chart-seed-data/04_skills.json
@@ -1,0 +1,254 @@
+[
+  {
+    "@id": "acme-corp",
+    "@graph": [
+      {
+        "id": "org:skills/javascript",
+        "type": "org:Skill",
+        "schema:name": "JavaScript",
+        "org:category": "Programming"
+      },
+      {
+        "id": "org:skills/python",
+        "type": "org:Skill",
+        "schema:name": "Python",
+        "org:category": "Programming"
+      },
+      {
+        "id": "org:skills/clojure",
+        "type": "org:Skill",
+        "schema:name": "Clojure",
+        "org:category": "Programming"
+      },
+      {
+        "id": "org:skills/sql",
+        "type": "org:Skill",
+        "schema:name": "SQL",
+        "org:category": "Database"
+      },
+      {
+        "id": "org:skills/graphql",
+        "type": "org:Skill",
+        "schema:name": "GraphQL",
+        "org:category": "API"
+      },
+      {
+        "id": "org:skills/aws",
+        "type": "org:Skill",
+        "schema:name": "AWS",
+        "org:category": "Cloud"
+      },
+      {
+        "id": "org:skills/kubernetes",
+        "type": "org:Skill",
+        "schema:name": "Kubernetes",
+        "org:category": "DevOps"
+      },
+      {
+        "id": "org:skills/react",
+        "type": "org:Skill",
+        "schema:name": "React",
+        "org:category": "Frontend"
+      },
+      {
+        "id": "org:skills/leadership",
+        "type": "org:Skill",
+        "schema:name": "Leadership",
+        "org:category": "Soft Skills"
+      },
+      {
+        "id": "org:skills/communication",
+        "type": "org:Skill",
+        "schema:name": "Communication",
+        "org:category": "Soft Skills"
+      },
+      {
+        "id": "org:skills/negotiation",
+        "type": "org:Skill",
+        "schema:name": "Negotiation",
+        "org:category": "Sales"
+      },
+      {
+        "id": "org:skills/content-strategy",
+        "type": "org:Skill",
+        "schema:name": "Content Strategy",
+        "org:category": "Marketing"
+      },
+      {
+        "id": "org:person-skills/alex-js",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/alex-rivera" },
+        "org:skill": { "id": "org:skills/javascript" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/alex-python",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/alex-rivera" },
+        "org:skill": { "id": "org:skills/python" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/alex-aws",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/alex-rivera" },
+        "org:skill": { "id": "org:skills/aws" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/alex-k8s",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/alex-rivera" },
+        "org:skill": { "id": "org:skills/kubernetes" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/emma-clojure",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/emma-wilson" },
+        "org:skill": { "id": "org:skills/clojure" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/emma-sql",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/emma-wilson" },
+        "org:skill": { "id": "org:skills/sql" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/emma-aws",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/emma-wilson" },
+        "org:skill": { "id": "org:skills/aws" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/michael-python",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/michael-brown" },
+        "org:skill": { "id": "org:skills/python" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/michael-k8s",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/michael-brown" },
+        "org:skill": { "id": "org:skills/kubernetes" },
+        "org:proficiency": "intermediate"
+      },
+      {
+        "id": "org:person-skills/sophia-js",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/sophia-martinez" },
+        "org:skill": { "id": "org:skills/javascript" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/sophia-graphql",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/sophia-martinez" },
+        "org:skill": { "id": "org:skills/graphql" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/jordan-react",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/jordan-patel" },
+        "org:skill": { "id": "org:skills/react" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/jordan-leadership",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/jordan-patel" },
+        "org:skill": { "id": "org:skills/leadership" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/james-react",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/james-taylor" },
+        "org:skill": { "id": "org:skills/react" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/james-js",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/james-taylor" },
+        "org:skill": { "id": "org:skills/javascript" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/olivia-react",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/olivia-garcia" },
+        "org:skill": { "id": "org:skills/react" },
+        "org:proficiency": "intermediate"
+      },
+      {
+        "id": "org:person-skills/william-js",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/william-anderson" },
+        "org:skill": { "id": "org:skills/javascript" },
+        "org:proficiency": "intermediate"
+      },
+      {
+        "id": "org:person-skills/lisa-negotiation",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/lisa-wong" },
+        "org:skill": { "id": "org:skills/negotiation" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/lisa-leadership",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/lisa-wong" },
+        "org:skill": { "id": "org:skills/leadership" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/ava-negotiation",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/ava-thomas" },
+        "org:skill": { "id": "org:skills/negotiation" },
+        "org:proficiency": "advanced"
+      },
+      {
+        "id": "org:person-skills/noah-content",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/noah-harris" },
+        "org:skill": { "id": "org:skills/content-strategy" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/marcus-leadership",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/marcus-johnson" },
+        "org:skill": { "id": "org:skills/leadership" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/marcus-clojure",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/marcus-johnson" },
+        "org:skill": { "id": "org:skills/clojure" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/sarah-leadership",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/sarah-chen" },
+        "org:skill": { "id": "org:skills/leadership" },
+        "org:proficiency": "expert"
+      },
+      {
+        "id": "org:person-skills/sarah-communication",
+        "type": "org:PersonSkill",
+        "org:person": { "id": "org:people/sarah-chen" },
+        "org:skill": { "id": "org:skills/communication" },
+        "org:proficiency": "expert"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/org-chart-seed-data/defaultContext.json
+++ b/docs/examples/datasets/org-chart-seed-data/defaultContext.json
@@ -1,0 +1,10 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "schema": "http://schema.org/",
+  "org": "https://org-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/org-chart/introduction.mdx
+++ b/docs/examples/datasets/org-chart/introduction.mdx
@@ -1,0 +1,124 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Org Chart & Team Structure
+
+This example demonstrates how to model organizational hierarchies and team structures using Fluree. You'll learn how to represent reporting relationships, departments, projects, and skills—patterns that appear in HR systems, team management tools, and enterprise applications.
+
+## The Scenario
+
+ACME Corp's HR team needs to:
+
+- Visualize the company's reporting structure
+- Find all employees who report to a specific manager (directly or indirectly)
+- Track which skills exist across teams
+- See who's working on which projects
+- Answer questions like "who are all the engineers under the CTO?"
+
+Graph databases are ideal for organizational data because the `reportsTo` relationship naturally forms a tree that can be traversed efficiently.
+
+## Schema Overview
+
+The organization is modeled with five main entity types:
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    p(Person) -->|reportsTo| m(Person)
+    p -->|department| d(Department)
+    d -->|parentDepartment| pd(Department)
+    p -->|member of| proj(Project)
+    proj -->|lead| p
+    ps(PersonSkill) -->|person| p
+    ps -->|skill| s(Skill)
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Person** | Employee with name, email, title, hire date |
+| **Department** | Organizational unit with optional parent |
+| **Project** | Work initiative with lead and members |
+| **Skill** | Technical or soft skill (e.g., JavaScript, Leadership) |
+| **PersonSkill** | Links a person to a skill with proficiency level |
+
+## The Reporting Hierarchy
+
+The `reportsTo` relationship creates a management tree:
+
+```
+Sarah Chen (CEO)
+├── Marcus Johnson (CTO)
+│   ├── Alex Rivera (Platform Lead)
+│   │   ├── Emma Wilson (Senior Platform Engineer)
+│   │   ├── Michael Brown (Platform Engineer)
+│   │   └── Sophia Martinez (Platform Engineer)
+│   └── Jordan Patel (Product Lead)
+│       ├── James Taylor (Senior Product Engineer)
+│       ├── Olivia Garcia (Product Engineer)
+│       └── William Anderson (Product Engineer)
+├── Lisa Wong (VP of Sales)
+│   └── Ava Thomas (Sales Manager)
+│       ├── Ethan Jackson (Account Executive)
+│       └── Mia White (Account Executive)
+├── David Kim (VP of Marketing)
+│   └── Noah Harris (Content Manager)
+│       └── Isabella Clark (Marketing Specialist)
+└── Rachel Green (HR Director)
+    └── Liam Lewis (HR Coordinator)
+```
+
+This hierarchy enables powerful transitive queries—finding everyone in someone's entire reporting chain.
+
+## Example Person
+
+Here's how an employee is represented:
+
+```json
+{
+  "id": "org:people/alex-rivera",
+  "type": "org:Person",
+  "schema:givenName": "Alex",
+  "schema:familyName": "Rivera",
+  "schema:email": "alex.rivera@acme.com",
+  "org:title": "Platform Lead",
+  "org:department": { "id": "org:departments/engineering/platform" },
+  "org:reportsTo": { "id": "org:people/marcus-johnson" },
+  "org:hireDate": "2019-11-18"
+}
+```
+
+The `reportsTo` relationship links to another person, creating the graph structure.
+
+## Skills Model
+
+Skills are tracked separately from people, with a proficiency level:
+
+```json
+{
+  "id": "org:person-skills/alex-aws",
+  "type": "org:PersonSkill",
+  "org:person": { "id": "org:people/alex-rivera" },
+  "org:skill": { "id": "org:skills/aws" },
+  "org:proficiency": "expert"
+}
+```
+
+This allows queries like "find all experts in Kubernetes" or "what skills does the Platform team have?"
+
+## What You'll Learn
+
+In the following pages, you'll explore:
+
+1. **[Querying](../querying/)** - Find direct reports, team members, and traverse the org tree
+2. **[Reasoning](../reasoning/)** - Use transitive queries to find all reports under a manager
+
+<Admonition type="tip">
+  The `reportsTo` relationship is a classic example of a graph pattern that's awkward in SQL (requiring recursive CTEs) but natural in a graph database.
+</Admonition>

--- a/docs/examples/datasets/org-chart/querying.mdx
+++ b/docs/examples/datasets/org-chart/querying.mdx
@@ -1,0 +1,255 @@
+---
+title: Querying the Org Chart
+---
+
+import Admonition from "@theme/Admonition";
+
+# Querying the Org Chart
+
+This walkthrough demonstrates common organizational queries—from simple lookups to complex graph traversals.
+
+## HR Reviews the Team Structure
+
+The HR team needs to answer various questions about the organization. Let's build queries for each.
+
+### List All Employees
+
+Start with a simple query to see everyone:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "?person", "@type": "org:Person" },
+  "orderBy": "?person"
+}
+```
+
+### Find Direct Reports
+
+Who reports directly to the CTO?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "?person", "@type": "org:Person", "org:reportsTo": {"@id": "org:people/marcus-johnson"} }
+}
+```
+
+Result: Alex Rivera (Platform Lead) and Jordan Patel (Product Lead).
+
+### Find a Person's Manager
+
+Who does Emma Wilson report to?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?manager": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "org:people/emma-wilson", "org:reportsTo": "?manager" }
+}
+```
+
+Result: Alex Rivera (Platform Lead).
+
+### Team Members by Department
+
+Find everyone in the Platform Team:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "?person", "@type": "org:Person", "org:department": {"@id": "org:departments/engineering/platform"} }
+}
+```
+
+Result: Alex Rivera, Emma Wilson, Michael Brown, Sophia Martinez.
+
+### Employees with Their Managers
+
+Show each person alongside their manager's name:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?firstName", "?lastName", "?title", "?managerFirstName", "?managerLastName"],
+  "where": [
+    { "@id": "?person", "@type": "org:Person", "schema:givenName": "?firstName", "schema:familyName": "?lastName", "org:title": "?title", "org:reportsTo": "?manager" },
+    { "@id": "?manager", "schema:givenName": "?managerFirstName", "schema:familyName": "?managerLastName" }
+  ]
+}
+```
+
+<Admonition type="info">
+  Note that Sarah Chen (CEO) won't appear in results since she has no manager—there's no `reportsTo` relationship to match.
+</Admonition>
+
+### Find Project Members
+
+Who's working on the Mobile App project?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "org:projects/mobile-app", "org:members": "?person" }
+}
+```
+
+Result: James Taylor, Olivia Garcia, William Anderson.
+
+### Projects a Person Works On
+
+What projects is Emma Wilson involved in?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?project": ["schema:name", "org:status"]
+  },
+  "where": [
+    { "@id": "?project", "@type": "org:Project" },
+    ["union",
+      [{ "@id": "?project", "org:members": {"@id": "org:people/emma-wilson"} }],
+      [{ "@id": "?project", "org:lead": {"@id": "org:people/emma-wilson"} }]
+    ]
+  ]
+}
+```
+
+The `union` clause finds projects where Emma is either a member or the lead.
+
+### Find Experts in a Skill
+
+Who are the JavaScript experts?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "?ps", "@type": "org:PersonSkill", "org:skill": {"@id": "org:skills/javascript"}, "org:proficiency": "expert", "org:person": "?person" }
+}
+```
+
+Result: Alex Rivera, James Taylor.
+
+### Skills in a Department
+
+What skills exist on the Platform Team?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?skillName", "(count ?person)"],
+  "where": [
+    { "@id": "?person", "org:department": {"@id": "org:departments/engineering/platform"} },
+    { "@id": "?ps", "org:person": "?person", "org:skill": "?skill" },
+    { "@id": "?skill", "schema:name": "?skillName" }
+  ],
+  "groupBy": "?skillName",
+  "orderBy": [{"desc": "(count ?person)"}]
+}
+```
+
+This groups by skill and counts how many people have each one.
+
+### Colleagues (Same Manager)
+
+Find Jordan Patel's colleagues—people with the same manager:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?colleague": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": [
+    { "@id": "org:people/jordan-patel", "org:reportsTo": "?manager" },
+    { "@id": "?colleague", "org:reportsTo": "?manager" },
+    ["filter", "(!= ?colleague {\"@id\": \"org:people/jordan-patel\"})"]
+  ]
+}
+```
+
+Result: Alex Rivera (they both report to Marcus Johnson).
+
+### Recent Hires
+
+Find employees hired in the last year:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title", "org:hireDate"]
+  },
+  "where": [
+    { "@id": "?person", "@type": "org:Person", "org:hireDate": "?hireDate" },
+    ["filter", "(>= ?hireDate \"2022-01-01\")"]
+  ],
+  "orderBy": [{"desc": "?hireDate"}]
+}
+```
+
+## Summary
+
+Key query patterns for organizational data:
+
+| Pattern | Use Case |
+|---------|----------|
+| **Direct relationship** | Find manager, find direct reports |
+| **Traverse via join** | Person → Department, PersonSkill → Skill |
+| **Union** | Match multiple conditions (member OR lead) |
+| **Filter with !=** | Exclude self from results |
+| **Group + Count** | Aggregate skills by department |
+| **Date filters** | Recent hires |
+
+Next, learn how to use [transitive queries](../reasoning/) to find everyone in a manager's entire reporting chain.

--- a/docs/examples/datasets/org-chart/reasoning.mdx
+++ b/docs/examples/datasets/org-chart/reasoning.mdx
@@ -1,0 +1,236 @@
+---
+title: Transitive Queries
+---
+
+import Admonition from "@theme/Admonition";
+
+# Transitive Queries & Reasoning
+
+One of the most powerful features of graph databases is the ability to traverse relationships transitively—following chains of connections without knowing how deep they go.
+
+## The Challenge
+
+HR needs to answer: "Who are ALL the people who report to the CTO, directly or indirectly?"
+
+With only direct relationship queries, you'd need to:
+1. Find Marcus Johnson's direct reports (Alex, Jordan)
+2. Find their direct reports (Emma, Michael, Sophia, James, Olivia, William)
+3. Continue until you run out of levels
+
+This is tedious and requires knowing the org depth in advance. With transitive queries, it's a single query.
+
+## Transitive Path Queries
+
+The `*` modifier enables transitive traversal. Let's find everyone under Marcus Johnson:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "?person", "org:reportsTo*": {"@id": "org:people/marcus-johnson"} }
+}
+```
+
+The `reportsTo*` pattern follows the `reportsTo` chain zero or more times. This returns:
+
+- Alex Rivera (direct report)
+- Jordan Patel (direct report)
+- Emma Wilson (reports to Alex)
+- Michael Brown (reports to Alex)
+- Sophia Martinez (reports to Alex)
+- James Taylor (reports to Jordan)
+- Olivia Garcia (reports to Jordan)
+- William Anderson (reports to Jordan)
+
+<Admonition type="info">
+  The `*` modifier means "zero or more hops." Use `+` for "one or more hops" if you want to exclude the starting node.
+</Admonition>
+
+## Management Chain (Upward Traversal)
+
+Find everyone in William Anderson's management chain up to the CEO:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?manager": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": { "@id": "org:people/william-anderson", "org:reportsTo+": "?manager" }
+}
+```
+
+Result (in order of the chain):
+1. Jordan Patel (Product Lead)
+2. Marcus Johnson (CTO)
+3. Sarah Chen (CEO)
+
+## Count Reports at Each Level
+
+How many people report to each manager (directly and indirectly)?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?managerName", "(count ?report)"],
+  "where": [
+    { "@id": "?manager", "@type": "org:Person", "schema:givenName": "?managerName" },
+    { "@id": "?report", "org:reportsTo+": "?manager" }
+  ],
+  "groupBy": "?managerName",
+  "orderBy": [{"desc": "(count ?report)"}]
+}
+```
+
+This shows Sarah Chen with the most reports (everyone), followed by Marcus Johnson, etc.
+
+## Find Common Manager
+
+Who is the lowest common manager of Emma Wilson and James Taylor?
+
+This requires finding where their management chains intersect:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?commonManager": ["schema:givenName", "schema:familyName", "org:title"]
+  },
+  "where": [
+    { "@id": "org:people/emma-wilson", "org:reportsTo+": "?commonManager" },
+    { "@id": "org:people/james-taylor", "org:reportsTo+": "?commonManager" }
+  ]
+}
+```
+
+Result: Marcus Johnson and Sarah Chen (both are in both chains). Marcus is the lowest common manager.
+
+## Organizational Depth
+
+How deep is the reporting structure from the CEO?
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?level", "(count ?person)"],
+  "where": [
+    { "@id": "?person", "@type": "org:Person" },
+    ["bind", "?level", "(count (path org:people/sarah-chen ^org:reportsTo* ?person))"]
+  ],
+  "groupBy": "?level",
+  "orderBy": "?level"
+}
+```
+
+<Admonition type="warning">
+  Path length queries can be more complex. The example above shows the concept—actual syntax may vary based on Fluree version.
+</Admonition>
+
+## All Engineering Staff
+
+Find everyone in Engineering and its sub-departments (Platform, Product):
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?person": ["schema:givenName", "schema:familyName", "org:title"],
+    "?deptName": []
+  },
+  "where": [
+    { "@id": "?person", "@type": "org:Person", "org:department": "?dept" },
+    { "@id": "?dept", "org:parentDepartment*": {"@id": "org:departments/engineering"}, "schema:name": "?deptName" }
+  ]
+}
+```
+
+This finds people whose department is Engineering or has Engineering as an ancestor.
+
+## Skill Gap Analysis
+
+Find skills that exist under the CTO but not on the Platform team:
+
+```json
+{
+  "@context": {
+    "org": "https://org-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?skillName"],
+  "where": [
+    { "@id": "?person", "org:reportsTo*": {"@id": "org:people/marcus-johnson"} },
+    { "@id": "?ps", "org:person": "?person", "org:skill": "?skill" },
+    { "@id": "?skill", "schema:name": "?skillName" },
+    {
+      "minus": [
+        { "@id": "?platformPerson", "org:department": {"@id": "org:departments/engineering/platform"} },
+        { "@id": "?platformPs", "org:person": "?platformPerson", "org:skill": "?skill" }
+      ]
+    }
+  ]
+}
+```
+
+The `minus` clause excludes skills that exist on the Platform team.
+
+## Comparison: SQL vs Graph
+
+In SQL, finding all reports under a manager requires a recursive CTE:
+
+```sql
+WITH RECURSIVE reports AS (
+  SELECT id, name, title, reports_to
+  FROM people
+  WHERE reports_to = 'marcus-johnson'
+
+  UNION ALL
+
+  SELECT p.id, p.name, p.title, p.reports_to
+  FROM people p
+  JOIN reports r ON p.reports_to = r.id
+)
+SELECT * FROM reports;
+```
+
+In Fluree, it's simply:
+
+```json
+{
+  "select": { "?person": ["*"] },
+  "where": { "@id": "?person", "org:reportsTo*": {"@id": "org:people/marcus-johnson"} }
+}
+```
+
+## Summary
+
+Transitive query patterns:
+
+| Pattern | Meaning |
+|---------|---------|
+| `reportsTo*` | Zero or more hops (includes self) |
+| `reportsTo+` | One or more hops (excludes self) |
+| `parentDepartment*` | Traverse department hierarchy |
+| Upward traversal | Find all managers in chain |
+| Common ancestor | Find shared manager |
+
+These patterns make organizational queries natural and efficient, without the complexity of recursive SQL or manual graph traversal.

--- a/docs/examples/datasets/supply-chain-seed-data/01_data.json
+++ b/docs/examples/datasets/supply-chain-seed-data/01_data.json
@@ -1,0 +1,68 @@
+[
+  {
+    "@id": "supply-chain",
+    "@graph": [
+      {
+        "id": "sc:orgs/acme-mfg",
+        "type": "sc:Organization",
+        "schema:name": "ACME Manufacturing",
+        "sc:orgType": "Manufacturer"
+      },
+      {
+        "id": "sc:orgs/global-dist",
+        "type": "sc:Organization",
+        "schema:name": "Global Distribution Co",
+        "sc:orgType": "Distributor"
+      },
+      {
+        "id": "sc:orgs/retail-mart",
+        "type": "sc:Organization",
+        "schema:name": "RetailMart",
+        "sc:orgType": "Retailer"
+      },
+      {
+        "id": "sc:locations/factory-1",
+        "type": "sc:Location",
+        "schema:name": "Factory 1",
+        "schema:address": "100 Industrial Blvd, Detroit, MI"
+      },
+      {
+        "id": "sc:locations/warehouse-east",
+        "type": "sc:Location",
+        "schema:name": "East Coast Warehouse",
+        "schema:address": "500 Commerce Way, Newark, NJ"
+      },
+      {
+        "id": "sc:locations/store-101",
+        "type": "sc:Location",
+        "schema:name": "Store #101",
+        "schema:address": "123 Main St, New York, NY"
+      },
+      {
+        "id": "sc:shipments/ship-001",
+        "type": "sc:Shipment",
+        "sc:origin": { "id": "sc:locations/factory-1" },
+        "sc:destination": { "id": "sc:locations/warehouse-east" },
+        "sc:sender": { "id": "sc:orgs/acme-mfg" },
+        "sc:receiver": { "id": "sc:orgs/global-dist" },
+        "sc:status": "delivered"
+      },
+      {
+        "id": "sc:events/e001",
+        "type": "sc:Event",
+        "sc:shipment": { "id": "sc:shipments/ship-001" },
+        "sc:eventType": "shipped",
+        "sc:timestamp": "2024-03-01T08:00:00Z",
+        "sc:location": { "id": "sc:locations/factory-1" }
+      },
+      {
+        "id": "sc:events/e002",
+        "type": "sc:Event",
+        "sc:shipment": { "id": "sc:shipments/ship-001" },
+        "sc:eventType": "received",
+        "sc:timestamp": "2024-03-03T14:30:00Z",
+        "sc:location": { "id": "sc:locations/warehouse-east" }
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/supply-chain-seed-data/defaultContext.json
+++ b/docs/examples/datasets/supply-chain-seed-data/defaultContext.json
@@ -1,0 +1,7 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "schema": "http://schema.org/",
+  "sc": "https://supply-chain-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/supply-chain/history.mdx
+++ b/docs/examples/datasets/supply-chain/history.mdx
@@ -1,0 +1,49 @@
+---
+title: Provenance & History
+---
+
+# Provenance & Audit Trail
+
+## Complete Event Timeline
+
+Track a shipment's journey with timestamps:
+
+```json
+{
+  "@context": { "sc": "https://supply-chain-example.com/ns/", "schema": "http://schema.org/" },
+  "select": ["?eventType", "?timestamp", "?locationName"],
+  "where": [
+    { "@id": "?event", "sc:shipment": {"@id": "sc:shipments/ship-001"}, "sc:eventType": "?eventType", "sc:timestamp": "?timestamp", "sc:location": "?loc" },
+    { "@id": "?loc", "schema:name": "?locationName" }
+  ],
+  "orderBy": "?timestamp"
+}
+```
+
+## Provenance Query
+
+Who handled this shipment?
+
+```json
+{
+  "select": ["?orgName", "?role"],
+  "where": [
+    ["union",
+      [
+        { "@id": "?shipment", "sc:sender": "?org" },
+        ["bind", "?role", "\"sender\""]
+      ],
+      [
+        { "@id": "?shipment", "sc:receiver": "?org" },
+        ["bind", "?role", "\"receiver\""]
+      ]
+    ],
+    { "@id": "?org", "schema:name": "?orgName" }
+  ],
+  "values": [["?shipment"], [{"@id": "sc:shipments/ship-001"}]]
+}
+```
+
+## Immutable Audit Trail
+
+All changes to shipment records are preserved in Fluree's history, enabling complete audit capability for compliance requirements.

--- a/docs/examples/datasets/supply-chain/introduction.mdx
+++ b/docs/examples/datasets/supply-chain/introduction.mdx
@@ -1,0 +1,34 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+
+# Supply Chain / Logistics
+
+Track shipments from factory to customer with full provenance and audit trail.
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    s(Shipment) -->|origin| l1(Location)
+    s -->|destination| l2(Location)
+    s -->|sender| o1(Organization)
+    s -->|receiver| o2(Organization)
+    e(Event) -->|shipment| s
+    e -->|location| l1
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Organization** | Supplier, Manufacturer, Distributor, Retailer |
+| **Location** | Factory, warehouse, store |
+| **Shipment** | Movement of goods between locations |
+| **Event** | Shipped, received, inspected timestamps |
+
+Graph queries enable powerful provenance tracking—follow the complete path of goods from origin to destination.

--- a/docs/examples/datasets/supply-chain/querying.mdx
+++ b/docs/examples/datasets/supply-chain/querying.mdx
@@ -1,0 +1,44 @@
+---
+title: Querying
+---
+
+# Querying Supply Chain Data
+
+## Track a Shipment
+
+Get all events for a shipment:
+
+```json
+{
+  "@context": { "sc": "https://supply-chain-example.com/ns/" },
+  "select": { "?event": ["sc:eventType", "sc:timestamp", "sc:location"] },
+  "where": { "@id": "?event", "sc:shipment": {"@id": "sc:shipments/ship-001"} },
+  "orderBy": "?timestamp"
+}
+```
+
+## Shipment Path
+
+Show origin to destination:
+
+```json
+{
+  "@context": { "sc": "https://supply-chain-example.com/ns/", "schema": "http://schema.org/" },
+  "select": ["?originName", "?destName", "?status"],
+  "where": [
+    { "@id": "sc:shipments/ship-001", "sc:origin": "?origin", "sc:destination": "?dest", "sc:status": "?status" },
+    { "@id": "?origin", "schema:name": "?originName" },
+    { "@id": "?dest", "schema:name": "?destName" }
+  ]
+}
+```
+
+## All Shipments by Organization
+
+```json
+{
+  "@context": { "sc": "https://supply-chain-example.com/ns/" },
+  "select": { "?shipment": ["sc:origin", "sc:destination", "sc:status"] },
+  "where": { "@id": "?shipment", "sc:sender": {"@id": "sc:orgs/acme-mfg"} }
+}
+```

--- a/docs/examples/home.md
+++ b/docs/examples/home.md
@@ -1,2 +1,45 @@
 # Examples
 
+Explore practical examples demonstrating Fluree's capabilities across different use cases and features.
+
+## Domain Examples
+
+Real-world scenarios showcasing graph modeling patterns:
+
+| Example | Description | Key Concepts |
+|---------|-------------|--------------|
+| [E-Commerce Catalog](/docs/examples/datasets/ecommerce/introduction) | Products, categories, variants, reviews | Graph traversal, filtering, aggregations |
+| [Org Chart](/docs/examples/datasets/org-chart/introduction) | People, departments, reporting hierarchy | Transitive queries, recursive relationships |
+| [Knowledge Base](/docs/examples/datasets/knowledge-base/introduction) | Articles, tags, citations, versions | Time-travel, citation graphs |
+| [Healthcare Records](/docs/examples/datasets/healthcare/introduction) | Patients, providers, appointments | HIPAA-style access control |
+| [Supply Chain](/docs/examples/datasets/supply-chain/introduction) | Shipments, locations, events | Provenance, audit trails |
+
+## Feature Showcases
+
+Deep dives into specific Fluree capabilities:
+
+| Example | Description | Key Concepts |
+|---------|-------------|--------------|
+| [Policy & Access Control](/docs/examples/datasets/access-control/introduction) | Multi-tenant SaaS with roles | Data-centric authorization |
+| [Reasoning & Inference](/docs/examples/datasets/reasoning/introduction) | Biology taxonomy | OWL properties, class hierarchies |
+| [Full-Text Search](/docs/examples/datasets/full-text-search/introduction) | Recipe search engine | BM25 ranking, stemming |
+| [SHACL Validation](/docs/examples/datasets/shacl-validation/introduction) | Data quality enforcement | Shapes, constraints |
+| [Time-Travel & Audit](/docs/examples/datasets/time-travel/introduction) | Financial audit trail | History queries, point-in-time |
+
+## Integration Guides
+
+Practical guides for adopting Fluree:
+
+| Guide | Description |
+|-------|-------------|
+| [SQL Migration](/docs/examples/datasets/sql-migration/introduction) | Mapping relational concepts to graphs |
+| [REST API Patterns](/docs/examples/datasets/rest-api/introduction) | HTTP operations with curl examples |
+
+## Getting Started
+
+Each example includes:
+- **Introduction**: Schema overview with Mermaid diagrams
+- **Seed Data**: JSON files to populate your ledger
+- **Query Walkthroughs**: Progressive examples from simple to complex
+
+Pick an example that matches your use case and follow along!


### PR DESCRIPTION
## Summary

Adds 5 domain-focused example datasets to **Examples > Domain Examples**:

### E-Commerce Catalog
- Product categories, brands, products, reviews
- Demonstrates hierarchical data and relationships

### Org Chart
- Departments, employees, projects, skills
- Demonstrates organizational modeling and reasoning

### Knowledge Base
- Articles with tags and cross-references
- Demonstrates content management patterns

### Healthcare Records
- Patients, providers, records with policies
- Demonstrates HIPAA-style access control

### Supply Chain
- Suppliers, products, shipments with history
- Demonstrates time-travel and audit trails

Each includes seed data JSON files and tutorial guides.

### Also updated
- **examples/home.md**: New examples landing page
- **academic-credentials/**: Minor fixes

## Test plan

- [ ] Load seed data into test instance
- [ ] Verify example queries work correctly