### PR TITLE
docs: add feature showcase examples

### DIFF
--- a/docs/examples/datasets/access-control-seed-data/01_users.json
+++ b/docs/examples/datasets/access-control-seed-data/01_users.json
@@ -1,0 +1,90 @@
+[
+  {
+    "@id": "multi-tenant-app",
+    "@graph": [
+      {
+        "id": "app:roles/admin",
+        "type": "app:Role",
+        "schema:name": "Admin",
+        "schema:description": "Full access to all resources in their organization"
+      },
+      {
+        "id": "app:roles/editor",
+        "type": "app:Role",
+        "schema:name": "Editor",
+        "schema:description": "Can create and edit documents"
+      },
+      {
+        "id": "app:roles/viewer",
+        "type": "app:Role",
+        "schema:name": "Viewer",
+        "schema:description": "Read-only access to documents"
+      },
+      {
+        "id": "app:users/alice",
+        "type": "app:User",
+        "schema:givenName": "Alice",
+        "schema:familyName": "Admin",
+        "schema:email": "alice@acme.com",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:role": { "id": "app:roles/admin" }
+      },
+      {
+        "id": "app:users/bob",
+        "type": "app:User",
+        "schema:givenName": "Bob",
+        "schema:familyName": "Builder",
+        "schema:email": "bob@acme.com",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:role": { "id": "app:roles/editor" }
+      },
+      {
+        "id": "app:users/carol",
+        "type": "app:User",
+        "schema:givenName": "Carol",
+        "schema:familyName": "Contractor",
+        "schema:email": "carol@acme.com",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:role": { "id": "app:roles/viewer" }
+      },
+      {
+        "id": "app:users/dan",
+        "type": "app:User",
+        "schema:givenName": "Dan",
+        "schema:familyName": "Developer",
+        "schema:email": "dan@globex.com",
+        "app:organization": { "id": "app:orgs/globex" },
+        "app:role": { "id": "app:roles/admin" }
+      },
+      {
+        "id": "app:users/eve",
+        "type": "app:User",
+        "schema:givenName": "Eve",
+        "schema:familyName": "Editor",
+        "schema:email": "eve@globex.com",
+        "app:organization": { "id": "app:orgs/globex" },
+        "app:role": { "id": "app:roles/editor" }
+      },
+      {
+        "id": "app:users/frank",
+        "type": "app:User",
+        "schema:givenName": "Frank",
+        "schema:familyName": "Finance",
+        "schema:email": "frank@acme.com",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:role": { "id": "app:roles/viewer" },
+        "app:department": "Finance"
+      },
+      {
+        "id": "app:users/grace",
+        "type": "app:User",
+        "schema:givenName": "Grace",
+        "schema:familyName": "HR",
+        "schema:email": "grace@acme.com",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:role": { "id": "app:roles/editor" },
+        "app:department": "HR"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/access-control-seed-data/02_organizations.json
+++ b/docs/examples/datasets/access-control-seed-data/02_organizations.json
@@ -1,0 +1,23 @@
+[
+  {
+    "@id": "multi-tenant-app",
+    "@graph": [
+      {
+        "id": "app:orgs/acme",
+        "type": "app:Organization",
+        "schema:name": "ACME Corporation",
+        "schema:description": "A multinational technology company",
+        "app:plan": "enterprise",
+        "app:createdAt": "2023-01-15"
+      },
+      {
+        "id": "app:orgs/globex",
+        "type": "app:Organization",
+        "schema:name": "Globex Industries",
+        "schema:description": "A global manufacturing company",
+        "app:plan": "professional",
+        "app:createdAt": "2023-06-20"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/access-control-seed-data/03_documents.json
+++ b/docs/examples/datasets/access-control-seed-data/03_documents.json
@@ -1,0 +1,98 @@
+[
+  {
+    "@id": "multi-tenant-app",
+    "@graph": [
+      {
+        "id": "app:docs/acme-roadmap",
+        "type": "app:Document",
+        "schema:name": "2024 Product Roadmap",
+        "schema:description": "Strategic product plans for the year",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:author": { "id": "app:users/alice" },
+        "app:visibility": "internal",
+        "app:createdAt": "2024-01-10",
+        "app:content": "Q1: Launch mobile app. Q2: API v3. Q3: Enterprise features. Q4: International expansion."
+      },
+      {
+        "id": "app:docs/acme-budget",
+        "type": "app:Document",
+        "schema:name": "2024 Budget Report",
+        "schema:description": "Confidential financial projections",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:author": { "id": "app:users/frank" },
+        "app:visibility": "confidential",
+        "app:department": "Finance",
+        "app:createdAt": "2024-01-05",
+        "app:content": "Total budget: $5M. Engineering: $2M. Marketing: $1.5M. Operations: $1.5M."
+      },
+      {
+        "id": "app:docs/acme-hr-policies",
+        "type": "app:Document",
+        "schema:name": "Employee Handbook",
+        "schema:description": "HR policies and procedures",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:author": { "id": "app:users/grace" },
+        "app:visibility": "internal",
+        "app:department": "HR",
+        "app:createdAt": "2024-01-02",
+        "app:content": "Welcome to ACME! This handbook covers our policies on PTO, benefits, and workplace conduct."
+      },
+      {
+        "id": "app:docs/acme-salaries",
+        "type": "app:Document",
+        "schema:name": "Salary Bands 2024",
+        "schema:description": "Confidential compensation data",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:author": { "id": "app:users/grace" },
+        "app:visibility": "confidential",
+        "app:department": "HR",
+        "app:createdAt": "2024-01-08",
+        "app:content": "Engineering L1: $80k-$100k. L2: $100k-$130k. L3: $130k-$160k. L4: $160k-$200k."
+      },
+      {
+        "id": "app:docs/acme-public-blog",
+        "type": "app:Document",
+        "schema:name": "Company Blog Post",
+        "schema:description": "Public announcement draft",
+        "app:organization": { "id": "app:orgs/acme" },
+        "app:author": { "id": "app:users/bob" },
+        "app:visibility": "public",
+        "app:createdAt": "2024-02-01",
+        "app:content": "We're excited to announce our new mobile app! Download it today."
+      },
+      {
+        "id": "app:docs/globex-roadmap",
+        "type": "app:Document",
+        "schema:name": "Globex Product Strategy",
+        "schema:description": "Manufacturing innovation plans",
+        "app:organization": { "id": "app:orgs/globex" },
+        "app:author": { "id": "app:users/dan" },
+        "app:visibility": "internal",
+        "app:createdAt": "2024-01-20",
+        "app:content": "Focus on automation and AI-driven quality control for 2024."
+      },
+      {
+        "id": "app:docs/globex-contracts",
+        "type": "app:Document",
+        "schema:name": "Supplier Contracts",
+        "schema:description": "Confidential supplier agreements",
+        "app:organization": { "id": "app:orgs/globex" },
+        "app:author": { "id": "app:users/dan" },
+        "app:visibility": "confidential",
+        "app:createdAt": "2024-01-25",
+        "app:content": "Contract terms with key suppliers. Confidential pricing and volume commitments."
+      },
+      {
+        "id": "app:docs/globex-public-docs",
+        "type": "app:Document",
+        "schema:name": "Product Specifications",
+        "schema:description": "Public product documentation",
+        "app:organization": { "id": "app:orgs/globex" },
+        "app:author": { "id": "app:users/eve" },
+        "app:visibility": "public",
+        "app:createdAt": "2024-02-05",
+        "app:content": "Technical specifications for our industrial equipment line."
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/access-control-seed-data/04_policies.json
+++ b/docs/examples/datasets/access-control-seed-data/04_policies.json
@@ -1,0 +1,106 @@
+[
+  {
+    "@id": "multi-tenant-app",
+    "@graph": [
+      {
+        "@id": "app:policies/tenant-isolation",
+        "type": ["f:Policy"],
+        "f:targetClass": { "@id": "app:Document" },
+        "f:allow": [
+          {
+            "@id": "app:policies/tenant-isolation/rule",
+            "f:targetRole": { "@id": "app:roles/viewer" },
+            "f:action": [{ "@id": "f:view" }],
+            "f:property": [{ "@id": "f:allProperties" }],
+            "f:where": {
+              "@list": [
+                { "@list": ["?$this", "app:organization", "?org"] },
+                { "@list": ["?$identity", "app:organization", "?org"] }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "@id": "app:policies/editor-create",
+        "type": ["f:Policy"],
+        "f:targetClass": { "@id": "app:Document" },
+        "f:allow": [
+          {
+            "@id": "app:policies/editor-create/rule",
+            "f:targetRole": { "@id": "app:roles/editor" },
+            "f:action": [{ "@id": "f:view" }, { "@id": "f:modify" }],
+            "f:property": [{ "@id": "f:allProperties" }],
+            "f:where": {
+              "@list": [
+                { "@list": ["?$this", "app:organization", "?org"] },
+                { "@list": ["?$identity", "app:organization", "?org"] },
+                { "@list": ["?$this", "app:visibility", "?vis"] },
+                { "filter": ["!=", "?vis", "confidential"] }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "@id": "app:policies/admin-full",
+        "type": ["f:Policy"],
+        "f:targetClass": { "@id": "app:Document" },
+        "f:allow": [
+          {
+            "@id": "app:policies/admin-full/rule",
+            "f:targetRole": { "@id": "app:roles/admin" },
+            "f:action": [{ "@id": "f:view" }, { "@id": "f:modify" }, { "@id": "f:delete" }],
+            "f:property": [{ "@id": "f:allProperties" }],
+            "f:where": {
+              "@list": [
+                { "@list": ["?$this", "app:organization", "?org"] },
+                { "@list": ["?$identity", "app:organization", "?org"] }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "@id": "app:policies/department-confidential",
+        "type": ["f:Policy"],
+        "f:targetClass": { "@id": "app:Document" },
+        "f:allow": [
+          {
+            "@id": "app:policies/department-confidential/rule",
+            "f:targetRole": { "@id": "app:roles/editor" },
+            "f:action": [{ "@id": "f:view" }],
+            "f:property": [{ "@id": "f:allProperties" }],
+            "f:where": {
+              "@list": [
+                { "@list": ["?$this", "app:organization", "?org"] },
+                { "@list": ["?$identity", "app:organization", "?org"] },
+                { "@list": ["?$this", "app:visibility", "confidential"] },
+                { "@list": ["?$this", "app:department", "?dept"] },
+                { "@list": ["?$identity", "app:department", "?dept"] }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "@id": "app:policies/public-read",
+        "type": ["f:Policy"],
+        "f:targetClass": { "@id": "app:Document" },
+        "f:allow": [
+          {
+            "@id": "app:policies/public-read/rule",
+            "f:targetRole": { "@id": "app:roles/viewer" },
+            "f:action": [{ "@id": "f:view" }],
+            "f:property": [{ "@id": "f:allProperties" }],
+            "f:where": {
+              "@list": [
+                { "@list": ["?$this", "app:visibility", "public"] }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/access-control-seed-data/defaultContext.json
+++ b/docs/examples/datasets/access-control-seed-data/defaultContext.json
@@ -1,0 +1,10 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "schema": "http://schema.org/",
+  "f": "https://ns.flur.ee/ledger#",
+  "app": "https://app-example.com/ns/"
+}

--- a/docs/examples/datasets/access-control/defining-policies.mdx
+++ b/docs/examples/datasets/access-control/defining-policies.mdx
@@ -1,0 +1,271 @@
+---
+title: Defining Policies
+---
+
+import Admonition from "@theme/Admonition";
+
+# Defining Access Control Policies
+
+This page walks through creating policies step by step, explaining each component of Fluree's policy model.
+
+## Policy Structure
+
+Every policy has these key components:
+
+```json
+{
+  "@id": "policy-id",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "TargetType" },
+  "f:allow": [
+    {
+      "f:targetRole": { "@id": "role" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": { "@list": [...] }
+    }
+  ]
+}
+```
+
+| Component | Purpose |
+|-----------|---------|
+| `f:targetClass` | Which entity type this policy applies to |
+| `f:targetRole` | Which users (by role) this rule affects |
+| `f:action` | Allowed operations: `f:view`, `f:modify`, `f:delete` |
+| `f:property` | Which properties can be accessed |
+| `f:where` | Conditions that must be true |
+
+## Policy 1: Tenant Isolation
+
+The foundational policy ensures users can only see their own organization's data.
+
+```json
+{
+  "@id": "app:policies/tenant-isolation",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "@id": "app:policies/tenant-isolation/rule",
+      "f:targetRole": { "@id": "app:roles/viewer" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:organization", "?org"] },
+          { "@list": ["?$identity", "app:organization", "?org"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**How it works:**
+
+1. `?$this` is a special variable representing the document being accessed
+2. `?$identity` represents the current user
+3. Both must have the same `?org` value—if not, the policy doesn't allow access
+
+<Admonition type="info">
+  The Viewer role is the base permission level. Higher roles (Editor, Admin) typically include all Viewer permissions plus additional capabilities.
+</Admonition>
+
+## Policy 2: Editor Permissions
+
+Editors can view and modify documents, but not confidential ones:
+
+```json
+{
+  "@id": "app:policies/editor-create",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "@id": "app:policies/editor-create/rule",
+      "f:targetRole": { "@id": "app:roles/editor" },
+      "f:action": [{ "@id": "f:view" }, { "@id": "f:modify" }],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:organization", "?org"] },
+          { "@list": ["?$identity", "app:organization", "?org"] },
+          { "@list": ["?$this", "app:visibility", "?vis"] },
+          { "filter": ["!=", "?vis", "confidential"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Key additions:**
+
+- Two actions: `f:view` and `f:modify`
+- Filter excludes confidential documents: `["!=", "?vis", "confidential"]`
+
+## Policy 3: Admin Full Access
+
+Admins have unrestricted access within their organization:
+
+```json
+{
+  "@id": "app:policies/admin-full",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "@id": "app:policies/admin-full/rule",
+      "f:targetRole": { "@id": "app:roles/admin" },
+      "f:action": [
+        { "@id": "f:view" },
+        { "@id": "f:modify" },
+        { "@id": "f:delete" }
+      ],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:organization", "?org"] },
+          { "@list": ["?$identity", "app:organization", "?org"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Key points:**
+
+- All three actions allowed
+- No visibility filter—admins see everything in their org
+- Still restricted to their own organization (tenant isolation)
+
+## Policy 4: Department-Based Confidential Access
+
+Confidential documents are visible to editors in the same department:
+
+```json
+{
+  "@id": "app:policies/department-confidential",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "@id": "app:policies/department-confidential/rule",
+      "f:targetRole": { "@id": "app:roles/editor" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:organization", "?org"] },
+          { "@list": ["?$identity", "app:organization", "?org"] },
+          { "@list": ["?$this", "app:visibility", "confidential"] },
+          { "@list": ["?$this", "app:department", "?dept"] },
+          { "@list": ["?$identity", "app:department", "?dept"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**How it works:**
+
+1. Document must be confidential
+2. Document must have a department
+3. User must be in that same department
+4. Still requires same organization
+
+This allows Grace (HR Editor) to see HR confidential docs, but not Finance confidential docs.
+
+## Policy 5: Public Content
+
+Public documents are visible to everyone, even across organizations:
+
+```json
+{
+  "@id": "app:policies/public-read",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "@id": "app:policies/public-read/rule",
+      "f:targetRole": { "@id": "app:roles/viewer" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:property": [{ "@id": "f:allProperties" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:visibility", "public"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Note:** No organization check—only requires `visibility = public`.
+
+## Property-Level Restrictions
+
+You can also restrict access to specific properties. For example, hiding salary information:
+
+```json
+{
+  "@id": "app:policies/hide-salary",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Employee" },
+  "f:allow": [
+    {
+      "f:targetRole": { "@id": "app:roles/viewer" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:property": [
+        { "@id": "schema:givenName" },
+        { "@id": "schema:familyName" },
+        { "@id": "schema:email" },
+        { "@id": "app:title" }
+      ]
+    }
+  ]
+}
+```
+
+Instead of `f:allProperties`, we list specific properties. The `app:salary` property is excluded, so viewers can't see it.
+
+## Adding Policies to the Ledger
+
+Policies are inserted like any other data:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "app": "https://app-example.com/ns/"
+  },
+  "insert": {
+    "@id": "app:policies/my-new-policy",
+    "type": ["f:Policy"],
+    "f:targetClass": { "@id": "app:Document" },
+    "f:allow": [...]
+  }
+}
+```
+
+<Admonition type="warning">
+  Policy changes take effect immediately. Test policies thoroughly in a development environment before applying to production.
+</Admonition>
+
+## Summary
+
+Policy design patterns:
+
+| Pattern | Use Case |
+|---------|----------|
+| **Match organization** | Tenant isolation |
+| **Match role** | Role-based access |
+| **Filter visibility** | Exclude sensitive content |
+| **Match department** | Department-scoped access |
+| **List properties** | Property-level restrictions |
+| **No org check** | Cross-tenant public content |
+
+Next, learn how to [test policies](../testing-policies/) by querying as different users.

--- a/docs/examples/datasets/access-control/introduction.mdx
+++ b/docs/examples/datasets/access-control/introduction.mdx
@@ -1,0 +1,115 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Policy & Access Control
+
+This example demonstrates Fluree's data-centric access control model. Unlike traditional application-layer authorization, Fluree policies are stored as data in the ledger itself, ensuring consistent enforcement across all queries and transactions.
+
+## The Scenario
+
+A multi-tenant SaaS application needs to:
+
+- **Isolate tenants**: Users from ACME should never see Globex's documents
+- **Enforce roles**: Admins can do everything, Editors can create/edit (but not delete), Viewers can only read
+- **Handle confidentiality**: Confidential documents are restricted to users in the same department
+- **Support public content**: Some documents are visible to everyone
+
+These requirements must be enforced consistently, regardless of how the data is accessed.
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    u(User) -->|organization| o(Organization)
+    u -->|role| r(Role)
+    d(Document) -->|organization| o
+    d -->|author| u
+    p(Policy) -.->|controls| d
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Organization** | Tenant (e.g., ACME, Globex) |
+| **User** | Person with role and organization membership |
+| **Role** | Permission level (Admin, Editor, Viewer) |
+| **Document** | Content with visibility (public, internal, confidential) |
+| **Policy** | Access control rules stored as data |
+
+## Users and Roles
+
+The example includes users across two organizations with different roles:
+
+| User | Organization | Role | Department |
+|------|--------------|------|------------|
+| Alice | ACME | Admin | - |
+| Bob | ACME | Editor | - |
+| Carol | ACME | Viewer | - |
+| Frank | ACME | Viewer | Finance |
+| Grace | ACME | Editor | HR |
+| Dan | Globex | Admin | - |
+| Eve | Globex | Editor | - |
+
+## Document Visibility Levels
+
+Documents have three visibility levels:
+
+| Level | Who Can See |
+|-------|-------------|
+| **public** | Everyone (even across organizations) |
+| **internal** | All users in the same organization |
+| **confidential** | Only users in the same department |
+
+## Policy Model
+
+Fluree policies are defined as data using the `f:Policy` type. Each policy specifies:
+
+- **Target class**: Which entity type the policy applies to
+- **Target role**: Which users the policy affects
+- **Actions**: What operations are allowed (view, modify, delete)
+- **Where clause**: Conditions that must be met
+
+Example policy structure:
+
+```json
+{
+  "@id": "app:policies/tenant-isolation",
+  "type": ["f:Policy"],
+  "f:targetClass": { "@id": "app:Document" },
+  "f:allow": [
+    {
+      "f:targetRole": { "@id": "app:roles/viewer" },
+      "f:action": [{ "@id": "f:view" }],
+      "f:where": {
+        "@list": [
+          { "@list": ["?$this", "app:organization", "?org"] },
+          { "@list": ["?$identity", "app:organization", "?org"] }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The `where` clause uses the same pattern language as queries:
+- `?$this` refers to the document being accessed
+- `?$identity` refers to the current user
+- The clause requires both to share the same organization (`?org`)
+
+## What You'll Learn
+
+In the following pages, you'll explore:
+
+1. **[Defining Policies](../defining-policies/)** - Create access control rules step by step
+2. **[Testing Policies](../testing-policies/)** - Query as different users and verify restrictions
+
+<Admonition type="tip">
+  Fluree's policy model treats authorization as data, which means policies are queryable, version-controlled, and auditable just like any other data in your ledger.
+</Admonition>

--- a/docs/examples/datasets/access-control/testing-policies.mdx
+++ b/docs/examples/datasets/access-control/testing-policies.mdx
@@ -1,0 +1,328 @@
+---
+title: Testing Policies
+---
+
+import Admonition from "@theme/Admonition";
+
+# Testing Access Control Policies
+
+This page demonstrates how to verify policies work correctly by querying as different users and observing what they can and cannot see.
+
+## Querying as a Specific User
+
+In Fluree, you specify the current user identity using the `opts` parameter:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/carol" }
+  }
+}
+```
+
+The `opts.identity` tells Fluree to apply policies as if Carol is making the request.
+
+## Test Case 1: Viewer Tenant Isolation
+
+Carol (ACME Viewer) queries all documents:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility", "app:organization"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/carol" }
+  }
+}
+```
+
+**Expected results:**
+
+Carol should see:
+- ACME documents with visibility `public` or `internal`
+- Globex documents with visibility `public` only
+
+Carol should NOT see:
+- Any confidential ACME documents (she's not in a department)
+- Any non-public Globex documents
+
+## Test Case 2: Cross-Tenant Isolation
+
+Dan (Globex Admin) queries all documents:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/dan" }
+  }
+}
+```
+
+**Expected results:**
+
+Dan should see:
+- All Globex documents (he's admin)
+- Public ACME documents only
+
+Dan should NOT see:
+- ACME internal or confidential documents (wrong organization)
+
+## Test Case 3: Editor with Confidential Filter
+
+Bob (ACME Editor) queries documents:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/bob" }
+  }
+}
+```
+
+**Expected results:**
+
+Bob should see:
+- All ACME public documents
+- All ACME internal documents
+- Public documents from Globex
+
+Bob should NOT see:
+- Confidential ACME documents (Bob has no department)
+- Non-public Globex documents
+
+## Test Case 4: Department-Scoped Confidential Access
+
+Grace (ACME HR Editor) queries documents:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility", "app:department"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/grace" }
+  }
+}
+```
+
+**Expected results:**
+
+Grace should see:
+- All ACME public and internal documents
+- ACME HR confidential documents (Salary Bands, Employee Handbook)
+- Public Globex documents
+
+Grace should NOT see:
+- ACME Finance confidential documents (wrong department)
+- Non-public Globex documents
+
+## Test Case 5: Admin Full Access
+
+Alice (ACME Admin) queries all documents:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?doc": ["schema:name", "app:visibility", "app:department"]
+  },
+  "where": { "@id": "?doc", "@type": "app:Document" },
+  "opts": {
+    "identity": { "@id": "app:users/alice" }
+  }
+}
+```
+
+**Expected results:**
+
+Alice should see:
+- ALL ACME documents (public, internal, and confidential)
+- Public Globex documents
+
+Alice should NOT see:
+- Non-public Globex documents
+
+## Test Case 6: Modification Permissions
+
+Test if Bob can modify a document:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "app": "https://app-example.com/ns/"
+  },
+  "delete": {
+    "id": "app:docs/acme-public-blog",
+    "schema:name": "Company Blog Post"
+  },
+  "insert": {
+    "id": "app:docs/acme-public-blog",
+    "schema:name": "Updated Blog Post Title"
+  },
+  "opts": {
+    "identity": { "@id": "app:users/bob" }
+  }
+}
+```
+
+**Expected:** Success—Bob is an Editor with modify permissions for public documents.
+
+Now test modifying a confidential document:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "app": "https://app-example.com/ns/"
+  },
+  "delete": {
+    "id": "app:docs/acme-budget",
+    "schema:name": "2024 Budget Report"
+  },
+  "insert": {
+    "id": "app:docs/acme-budget",
+    "schema:name": "Hacked Budget"
+  },
+  "opts": {
+    "identity": { "@id": "app:users/bob" }
+  }
+}
+```
+
+**Expected:** Failure—Bob cannot modify confidential documents.
+
+## Test Case 7: Delete Permissions
+
+Test if Carol can delete a document:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/"
+  },
+  "delete": {
+    "id": "app:docs/acme-public-blog",
+    "app:content": null
+  },
+  "opts": {
+    "identity": { "@id": "app:users/carol" }
+  }
+}
+```
+
+**Expected:** Failure—Viewers cannot delete.
+
+Test if Alice can delete:
+
+```json
+{
+  "@context": {
+    "app": "https://app-example.com/ns/"
+  },
+  "delete": {
+    "id": "app:docs/acme-public-blog",
+    "app:content": null
+  },
+  "opts": {
+    "identity": { "@id": "app:users/alice" }
+  }
+}
+```
+
+**Expected:** Success—Admins can delete.
+
+## Debugging Policy Issues
+
+If a policy isn't working as expected:
+
+### 1. Check the user's role
+
+```json
+{
+  "select": {
+    "?user": ["schema:givenName", "app:role", "app:organization", "app:department"]
+  },
+  "where": { "@id": "app:users/grace" }
+}
+```
+
+### 2. Check the document's properties
+
+```json
+{
+  "select": {
+    "?doc": ["*"]
+  },
+  "where": { "@id": "app:docs/acme-salaries" }
+}
+```
+
+### 3. Query policies directly
+
+```json
+{
+  "select": {
+    "?policy": ["*"]
+  },
+  "where": { "@id": "?policy", "@type": "f:Policy" }
+}
+```
+
+<Admonition type="tip">
+  When debugging, temporarily remove filters from your policy's `where` clause to see if the basic role/organization matching works. Then add constraints back one at a time.
+</Admonition>
+
+## Summary
+
+Key testing patterns:
+
+| Test | What to Verify |
+|------|----------------|
+| **Tenant isolation** | Users see only their org's data |
+| **Role escalation** | Higher roles don't break lower restrictions |
+| **Cross-tenant** | Admins can't bypass tenant boundaries |
+| **Department scope** | Confidential docs respect department |
+| **Public access** | Public content visible across orgs |
+| **Write permissions** | Editors can modify, viewers cannot |
+| **Delete permissions** | Only admins can delete |
+
+Policies provide defense-in-depth—even if application code has a bug, the database enforces access rules consistently.

--- a/docs/examples/datasets/full-text-search-seed-data/01_recipes.json
+++ b/docs/examples/datasets/full-text-search-seed-data/01_recipes.json
@@ -1,0 +1,222 @@
+[
+  {
+    "@id": "recipe-database",
+    "@graph": [
+      {
+        "id": "recipe:cuisines/italian",
+        "type": "recipe:Cuisine",
+        "schema:name": "Italian"
+      },
+      {
+        "id": "recipe:cuisines/mexican",
+        "type": "recipe:Cuisine",
+        "schema:name": "Mexican"
+      },
+      {
+        "id": "recipe:cuisines/asian",
+        "type": "recipe:Cuisine",
+        "schema:name": "Asian"
+      },
+      {
+        "id": "recipe:cuisines/american",
+        "type": "recipe:Cuisine",
+        "schema:name": "American"
+      },
+      {
+        "id": "recipe:cuisines/mediterranean",
+        "type": "recipe:Cuisine",
+        "schema:name": "Mediterranean"
+      },
+      {
+        "id": "recipe:diets/vegetarian",
+        "type": "recipe:DietaryRestriction",
+        "schema:name": "Vegetarian"
+      },
+      {
+        "id": "recipe:diets/vegan",
+        "type": "recipe:DietaryRestriction",
+        "schema:name": "Vegan"
+      },
+      {
+        "id": "recipe:diets/gluten-free",
+        "type": "recipe:DietaryRestriction",
+        "schema:name": "Gluten-Free"
+      },
+      {
+        "id": "recipe:diets/dairy-free",
+        "type": "recipe:DietaryRestriction",
+        "schema:name": "Dairy-Free"
+      },
+      {
+        "id": "recipe:authors/chef-maria",
+        "type": "recipe:Author",
+        "schema:name": "Chef Maria",
+        "schema:description": "Italian cuisine specialist with 20 years experience"
+      },
+      {
+        "id": "recipe:authors/chef-carlos",
+        "type": "recipe:Author",
+        "schema:name": "Chef Carlos",
+        "schema:description": "Expert in Mexican and Latin American cooking"
+      },
+      {
+        "id": "recipe:authors/chef-lee",
+        "type": "recipe:Author",
+        "schema:name": "Chef Lee",
+        "schema:description": "Asian fusion chef and cookbook author"
+      },
+      {
+        "id": "recipe:recipes/spaghetti-carbonara",
+        "type": "recipe:Recipe",
+        "schema:name": "Classic Spaghetti Carbonara",
+        "schema:description": "A rich and creamy Roman pasta dish made with eggs, cheese, pancetta, and black pepper. This traditional recipe creates a silky sauce without using cream.",
+        "recipe:cuisine": { "id": "recipe:cuisines/italian" },
+        "recipe:author": { "id": "recipe:authors/chef-maria" },
+        "recipe:prepTime": 15,
+        "recipe:cookTime": 20,
+        "recipe:servings": 4,
+        "recipe:ingredients": "spaghetti, eggs, pecorino romano, guanciale, black pepper, salt",
+        "recipe:instructions": "Cook pasta until al dente. Fry guanciale until crispy. Mix eggs with cheese. Combine hot pasta with guanciale, remove from heat, add egg mixture. Toss quickly to create creamy sauce."
+      },
+      {
+        "id": "recipe:recipes/margherita-pizza",
+        "type": "recipe:Recipe",
+        "schema:name": "Authentic Margherita Pizza",
+        "schema:description": "The classic Neapolitan pizza with fresh tomatoes, mozzarella, and basil. Simple ingredients showcase the beauty of Italian cooking.",
+        "recipe:cuisine": { "id": "recipe:cuisines/italian" },
+        "recipe:author": { "id": "recipe:authors/chef-maria" },
+        "recipe:prepTime": 30,
+        "recipe:cookTime": 15,
+        "recipe:servings": 2,
+        "recipe:ingredients": "pizza dough, san marzano tomatoes, fresh mozzarella, fresh basil, olive oil, salt",
+        "recipe:instructions": "Stretch dough into circle. Spread crushed tomatoes. Add torn mozzarella. Bake at 500F until crust is golden and cheese bubbles. Top with fresh basil and olive oil."
+      },
+      {
+        "id": "recipe:recipes/tacos-al-pastor",
+        "type": "recipe:Recipe",
+        "schema:name": "Tacos al Pastor",
+        "schema:description": "Mexican street tacos with marinated pork, pineapple, and fresh cilantro. The smoky, sweet, and savory flavors come from the adobo marinade and grilled pineapple.",
+        "recipe:cuisine": { "id": "recipe:cuisines/mexican" },
+        "recipe:author": { "id": "recipe:authors/chef-carlos" },
+        "recipe:prepTime": 45,
+        "recipe:cookTime": 30,
+        "recipe:servings": 6,
+        "recipe:ingredients": "pork shoulder, dried chiles, pineapple, corn tortillas, onion, cilantro, lime",
+        "recipe:instructions": "Marinate pork in adobo sauce overnight. Grill pork with pineapple until caramelized. Slice thin. Serve on warm tortillas with onion, cilantro, and lime."
+      },
+      {
+        "id": "recipe:recipes/guacamole",
+        "type": "recipe:Recipe",
+        "schema:name": "Fresh Guacamole",
+        "schema:description": "Creamy avocado dip with lime, cilantro, and jalapeño. Perfect for chips or as a topping for tacos and burritos.",
+        "recipe:cuisine": { "id": "recipe:cuisines/mexican" },
+        "recipe:author": { "id": "recipe:authors/chef-carlos" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/vegan" },
+          { "id": "recipe:diets/gluten-free" }
+        ],
+        "recipe:prepTime": 10,
+        "recipe:cookTime": 0,
+        "recipe:servings": 4,
+        "recipe:ingredients": "ripe avocados, lime juice, red onion, jalapeño, cilantro, salt, tomato",
+        "recipe:instructions": "Mash avocados to desired consistency. Add lime juice, diced onion, minced jalapeño, chopped cilantro, and salt. Fold in diced tomato. Serve immediately."
+      },
+      {
+        "id": "recipe:recipes/pad-thai",
+        "type": "recipe:Recipe",
+        "schema:name": "Authentic Pad Thai",
+        "schema:description": "Thailand's famous stir-fried rice noodles with shrimp, tofu, eggs, and tamarind sauce. The balance of sweet, sour, salty, and spicy defines this iconic dish.",
+        "recipe:cuisine": { "id": "recipe:cuisines/asian" },
+        "recipe:author": { "id": "recipe:authors/chef-lee" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/gluten-free" }
+        ],
+        "recipe:prepTime": 20,
+        "recipe:cookTime": 15,
+        "recipe:servings": 4,
+        "recipe:ingredients": "rice noodles, shrimp, tofu, eggs, bean sprouts, tamarind paste, fish sauce, palm sugar, garlic, peanuts, lime",
+        "recipe:instructions": "Soak noodles until pliable. Make tamarind sauce. Stir-fry garlic, add shrimp and tofu. Push aside, scramble eggs. Add noodles and sauce. Toss with bean sprouts. Serve with peanuts and lime."
+      },
+      {
+        "id": "recipe:recipes/miso-soup",
+        "type": "recipe:Recipe",
+        "schema:name": "Traditional Miso Soup",
+        "schema:description": "A warming Japanese soup with fermented soybean paste, tofu, and seaweed. Simple but deeply flavorful, often served with rice and pickles.",
+        "recipe:cuisine": { "id": "recipe:cuisines/asian" },
+        "recipe:author": { "id": "recipe:authors/chef-lee" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/vegetarian" },
+          { "id": "recipe:diets/dairy-free" }
+        ],
+        "recipe:prepTime": 10,
+        "recipe:cookTime": 10,
+        "recipe:servings": 4,
+        "recipe:ingredients": "dashi stock, white miso paste, silken tofu, wakame seaweed, green onion",
+        "recipe:instructions": "Heat dashi stock. Add wakame and tofu cubes. Remove from heat. Whisk miso paste with a little stock, then stir into soup. Serve immediately with sliced green onion."
+      },
+      {
+        "id": "recipe:recipes/chocolate-brownies",
+        "type": "recipe:Recipe",
+        "schema:name": "Fudgy Chocolate Brownies",
+        "schema:description": "Dense, rich chocolate brownies with a crackly top and gooey center. Perfect for chocolate lovers who want intense cocoa flavor in every bite.",
+        "recipe:cuisine": { "id": "recipe:cuisines/american" },
+        "recipe:author": { "id": "recipe:authors/chef-maria" },
+        "recipe:prepTime": 15,
+        "recipe:cookTime": 25,
+        "recipe:servings": 12,
+        "recipe:ingredients": "butter, dark chocolate, sugar, eggs, vanilla, flour, cocoa powder, salt",
+        "recipe:instructions": "Melt butter and chocolate together. Whisk in sugar and eggs. Add vanilla. Fold in flour, cocoa, and salt. Pour into greased pan. Bake at 350F until set but still fudgy."
+      },
+      {
+        "id": "recipe:recipes/hummus",
+        "type": "recipe:Recipe",
+        "schema:name": "Creamy Hummus",
+        "schema:description": "Smooth chickpea dip with tahini, lemon, and garlic. A Mediterranean staple perfect with pita bread, vegetables, or as a sandwich spread.",
+        "recipe:cuisine": { "id": "recipe:cuisines/mediterranean" },
+        "recipe:author": { "id": "recipe:authors/chef-carlos" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/vegan" },
+          { "id": "recipe:diets/gluten-free" }
+        ],
+        "recipe:prepTime": 15,
+        "recipe:cookTime": 0,
+        "recipe:servings": 6,
+        "recipe:ingredients": "chickpeas, tahini, lemon juice, garlic, olive oil, cumin, salt, paprika",
+        "recipe:instructions": "Blend chickpeas with tahini, lemon juice, garlic, and cumin. Add cold water to reach desired consistency. Season with salt. Serve drizzled with olive oil and sprinkled with paprika."
+      },
+      {
+        "id": "recipe:recipes/veggie-stir-fry",
+        "type": "recipe:Recipe",
+        "schema:name": "Asian Vegetable Stir-Fry",
+        "schema:description": "A quick and healthy dish with crisp vegetables in a savory ginger soy sauce. High heat cooking keeps vegetables vibrant and crunchy.",
+        "recipe:cuisine": { "id": "recipe:cuisines/asian" },
+        "recipe:author": { "id": "recipe:authors/chef-lee" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/vegan" },
+          { "id": "recipe:diets/dairy-free" }
+        ],
+        "recipe:prepTime": 15,
+        "recipe:cookTime": 10,
+        "recipe:servings": 4,
+        "recipe:ingredients": "broccoli, bell peppers, snap peas, carrots, garlic, ginger, soy sauce, sesame oil, vegetable oil",
+        "recipe:instructions": "Heat wok until smoking. Add oil and vegetables in order of cooking time. Stir-fry until crisp-tender. Add garlic and ginger. Sauce with soy and sesame oil. Serve immediately over rice."
+      },
+      {
+        "id": "recipe:recipes/banana-bread",
+        "type": "recipe:Recipe",
+        "schema:name": "Classic Banana Bread",
+        "schema:description": "Moist and tender quick bread made with overripe bananas. The natural sweetness of ripe bananas creates an irresistible flavor and tender crumb.",
+        "recipe:cuisine": { "id": "recipe:cuisines/american" },
+        "recipe:author": { "id": "recipe:authors/chef-maria" },
+        "recipe:dietaryRestrictions": [
+          { "id": "recipe:diets/vegetarian" }
+        ],
+        "recipe:prepTime": 15,
+        "recipe:cookTime": 60,
+        "recipe:servings": 8,
+        "recipe:ingredients": "ripe bananas, butter, sugar, eggs, vanilla, flour, baking soda, salt, walnuts",
+        "recipe:instructions": "Mash bananas. Cream butter and sugar. Add eggs and vanilla. Combine dry ingredients. Fold wet into dry. Add nuts. Bake at 350F until toothpick comes out clean."
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/full-text-search-seed-data/defaultContext.json
+++ b/docs/examples/datasets/full-text-search-seed-data/defaultContext.json
@@ -1,0 +1,8 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "schema": "http://schema.org/",
+  "recipe": "https://recipe-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/full-text-search/introduction.mdx
+++ b/docs/examples/datasets/full-text-search/introduction.mdx
@@ -1,0 +1,79 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Full-Text Search
+
+This example demonstrates Fluree's full-text search capabilities using a recipe database. You'll learn how to index text content and perform relevance-ranked searches.
+
+## The Scenario
+
+A recipe website needs to:
+
+- Search recipes by ingredient ("find recipes with chicken")
+- Search recipe descriptions and instructions
+- Rank results by relevance
+- Combine text search with graph filters (e.g., "vegan recipes containing tofu")
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph LR
+    r(Recipe) -->|cuisine| c(Cuisine)
+    r -->|author| a(Author)
+    r -->|dietaryRestrictions| d(DietaryRestriction)
+  `}
+/>
+
+### Entities
+
+| Entity | Description |
+|--------|-------------|
+| **Recipe** | Name, description, ingredients, instructions |
+| **Cuisine** | Type of cuisine (Italian, Mexican, Asian, etc.) |
+| **Author** | Chef who created the recipe |
+| **DietaryRestriction** | Diet compatibility (Vegan, Vegetarian, Gluten-Free) |
+
+## Example Recipe
+
+```json
+{
+  "id": "recipe:recipes/pad-thai",
+  "type": "recipe:Recipe",
+  "schema:name": "Authentic Pad Thai",
+  "schema:description": "Thailand's famous stir-fried rice noodles with shrimp, tofu, eggs, and tamarind sauce...",
+  "recipe:cuisine": { "id": "recipe:cuisines/asian" },
+  "recipe:author": { "id": "recipe:authors/chef-lee" },
+  "recipe:prepTime": 20,
+  "recipe:cookTime": 15,
+  "recipe:servings": 4,
+  "recipe:ingredients": "rice noodles, shrimp, tofu, eggs, bean sprouts, tamarind paste...",
+  "recipe:instructions": "Soak noodles until pliable. Make tamarind sauce..."
+}
+```
+
+The `ingredients`, `description`, and `instructions` fields are ideal for full-text indexing.
+
+## BM25 Search Algorithm
+
+Fluree uses the BM25 algorithm for full-text search ranking. BM25 considers:
+
+- **Term frequency**: How often the search term appears in a document
+- **Inverse document frequency**: Rarer terms are weighted higher
+- **Document length normalization**: Longer documents don't unfairly dominate
+
+This produces intuitive relevance rankings—documents with more occurrences of rarer search terms rank higher.
+
+## What You'll Learn
+
+In the following pages, you'll explore:
+
+1. **[Search Queries](../search-queries/)** - Perform text searches with relevance ranking
+
+<Admonition type="info">
+  Full-text search complements graph queries—use text search to find candidates, then traverse relationships for richer results.
+</Admonition>

--- a/docs/examples/datasets/full-text-search/search-queries.mdx
+++ b/docs/examples/datasets/full-text-search/search-queries.mdx
@@ -1,0 +1,273 @@
+---
+title: Search Queries
+---
+
+import Admonition from "@theme/Admonition";
+
+# Full-Text Search Queries
+
+This page demonstrates how to perform text searches and combine them with graph queries.
+
+## Basic Text Search
+
+Search for recipes containing "chocolate":
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "schema:description"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe" },
+    { "@id": "?recipe", "f:fullText": "chocolate" }
+  ]
+}
+```
+
+This searches all indexed text fields for "chocolate" and returns matching recipes.
+
+## Search with Relevance Scores
+
+Get relevance scores to understand why results ranked:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": ["?name", "?score"],
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "schema:name": "?name" },
+    { "@id": "?recipe", "f:fullText": "?search" },
+    { "@id": "?search", "f:query": "pasta", "f:score": "?score" }
+  ],
+  "orderBy": [{"desc": "?score"}]
+}
+```
+
+Higher scores indicate better matches.
+
+## Search Specific Fields
+
+Search only in the ingredients field:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "recipe:ingredients"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:ingredients": "?ingredients" },
+    { "@id": "?ingredients", "f:fullText": "garlic" }
+  ]
+}
+```
+
+This finds recipes where "garlic" appears in the ingredients.
+
+## Multi-Term Search
+
+Search for multiple terms:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe" },
+    { "@id": "?recipe", "f:fullText": "creamy cheese" }
+  ]
+}
+```
+
+Recipes containing both "creamy" and "cheese" will rank highest.
+
+## Combine Search with Graph Filters
+
+Find vegan recipes mentioning "tofu":
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "schema:description"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:dietaryRestrictions": {"@id": "recipe:diets/vegan"} },
+    { "@id": "?recipe", "f:fullText": "tofu" }
+  ]
+}
+```
+
+This uses both:
+- Graph filter: `recipe:dietaryRestrictions` = vegan
+- Text search: contains "tofu"
+
+## Search by Cuisine
+
+Find Italian recipes with "tomato":
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "recipe:cuisine"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:cuisine": {"@id": "recipe:cuisines/italian"} },
+    { "@id": "?recipe", "f:fullText": "tomato" }
+  ]
+}
+```
+
+## Stemming Effects
+
+Fluree's text search includes stemming—word variations are matched:
+
+```json
+{
+  "where": { "@id": "?recipe", "f:fullText": "baking" }
+}
+```
+
+This matches:
+- "bake"
+- "baked"
+- "baking"
+- "baker"
+
+<Admonition type="info">
+  Stemming helps users find results even if they don't use the exact word form in the document.
+</Admonition>
+
+## Quick Recipe Finder
+
+Find recipes under 30 minutes prep that contain specific ingredients:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "recipe:prepTime", "recipe:cookTime"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:prepTime": "?prep" },
+    ["filter", "(< ?prep 30)"],
+    { "@id": "?recipe", "f:fullText": "avocado lime" }
+  ]
+}
+```
+
+## Dietary-Friendly Search
+
+Find gluten-free recipes with specific ingredients:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name"],
+    "?diet": []
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:dietaryRestrictions": "?restriction" },
+    { "@id": "?restriction", "schema:name": "?diet" },
+    { "@id": "?recipe", "f:fullText": "noodles" }
+  ]
+}
+```
+
+## Author's Recipes Search
+
+Find Chef Lee's recipes that mention "soy sauce":
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name", "recipe:instructions"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe", "recipe:author": {"@id": "recipe:authors/chef-lee"} },
+    { "@id": "?recipe", "f:fullText": "soy sauce" }
+  ]
+}
+```
+
+## Negative Search (Exclude Terms)
+
+Find chocolate recipes that don't mention "nuts":
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "schema": "http://schema.org/",
+    "recipe": "https://recipe-example.com/ns/"
+  },
+  "select": {
+    "?recipe": ["schema:name"]
+  },
+  "where": [
+    { "@id": "?recipe", "@type": "recipe:Recipe" },
+    { "@id": "?recipe", "f:fullText": "chocolate" },
+    {
+      "minus": { "@id": "?recipe", "f:fullText": "nuts" }
+    }
+  ]
+}
+```
+
+## Summary
+
+Full-text search patterns:
+
+| Pattern | Use Case |
+|---------|----------|
+| Basic search | Find documents containing term |
+| Field-specific | Search only ingredients, description, etc. |
+| Multi-term | Documents with multiple terms rank higher |
+| With graph filters | Combine text + relationship constraints |
+| Stemming | Match word variations automatically |
+| Negative search | Exclude documents with certain terms |
+| Relevance scores | Understand ranking factors |
+
+Full-text search transforms Fluree from a graph database into a searchable knowledge base—perfect for applications that need both structured queries and freeform search.

--- a/docs/examples/datasets/reasoning-seed-data/01_taxonomy.json
+++ b/docs/examples/datasets/reasoning-seed-data/01_taxonomy.json
@@ -1,0 +1,113 @@
+[
+  {
+    "@id": "biology-taxonomy",
+    "@graph": [
+      {
+        "id": "bio:classes/Animal",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Animal",
+        "rdfs:comment": "Kingdom Animalia - multicellular eukaryotic organisms"
+      },
+      {
+        "id": "bio:classes/Mammal",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Mammal",
+        "rdfs:subClassOf": { "id": "bio:classes/Animal" },
+        "rdfs:comment": "Warm-blooded vertebrates with hair and mammary glands"
+      },
+      {
+        "id": "bio:classes/Bird",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Bird",
+        "rdfs:subClassOf": { "id": "bio:classes/Animal" },
+        "rdfs:comment": "Warm-blooded vertebrates with feathers and beaks"
+      },
+      {
+        "id": "bio:classes/Reptile",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Reptile",
+        "rdfs:subClassOf": { "id": "bio:classes/Animal" },
+        "rdfs:comment": "Cold-blooded vertebrates with scales"
+      },
+      {
+        "id": "bio:classes/Carnivore",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Carnivore",
+        "rdfs:subClassOf": { "id": "bio:classes/Mammal" },
+        "rdfs:comment": "Mammals that primarily eat meat"
+      },
+      {
+        "id": "bio:classes/Herbivore",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Herbivore",
+        "rdfs:subClassOf": { "id": "bio:classes/Mammal" },
+        "rdfs:comment": "Mammals that primarily eat plants"
+      },
+      {
+        "id": "bio:classes/Feline",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Feline",
+        "rdfs:subClassOf": { "id": "bio:classes/Carnivore" },
+        "rdfs:comment": "Cat family (Felidae)"
+      },
+      {
+        "id": "bio:classes/Canine",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Canine",
+        "rdfs:subClassOf": { "id": "bio:classes/Carnivore" },
+        "rdfs:comment": "Dog family (Canidae)"
+      },
+      {
+        "id": "bio:classes/Primate",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Primate",
+        "rdfs:subClassOf": { "id": "bio:classes/Mammal" },
+        "rdfs:comment": "Order Primates including apes and monkeys"
+      },
+      {
+        "id": "bio:classes/Rodent",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Rodent",
+        "rdfs:subClassOf": { "id": "bio:classes/Mammal" },
+        "rdfs:comment": "Order Rodentia"
+      },
+      {
+        "id": "bio:classes/Raptor",
+        "type": ["rdfs:Class", "bio:TaxonomicClass"],
+        "rdfs:label": "Raptor",
+        "rdfs:subClassOf": { "id": "bio:classes/Bird" },
+        "rdfs:comment": "Birds of prey"
+      },
+      {
+        "id": "bio:habitats/Forest",
+        "type": "bio:Habitat",
+        "schema:name": "Forest",
+        "schema:description": "Wooded areas with dense tree coverage"
+      },
+      {
+        "id": "bio:habitats/Grassland",
+        "type": "bio:Habitat",
+        "schema:name": "Grassland",
+        "schema:description": "Open areas dominated by grasses"
+      },
+      {
+        "id": "bio:habitats/Arctic",
+        "type": "bio:Habitat",
+        "schema:name": "Arctic",
+        "schema:description": "Polar regions with extreme cold"
+      },
+      {
+        "id": "bio:habitats/Ocean",
+        "type": "bio:Habitat",
+        "schema:name": "Ocean",
+        "schema:description": "Marine environments"
+      },
+      {
+        "id": "bio:habitats/Desert",
+        "type": "bio:Habitat",
+        "schema:name": "Desert",
+        "schema:description": "Arid regions with minimal rainfall"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/reasoning-seed-data/02_organisms.json
+++ b/docs/examples/datasets/reasoning-seed-data/02_organisms.json
@@ -1,0 +1,131 @@
+[
+  {
+    "@id": "biology-taxonomy",
+    "@graph": [
+      {
+        "id": "bio:organisms/lion",
+        "type": ["bio:Organism", "bio:classes/Feline"],
+        "schema:name": "Lion",
+        "bio:scientificName": "Panthera leo",
+        "bio:habitat": { "id": "bio:habitats/Grassland" },
+        "bio:conservationStatus": "Vulnerable",
+        "bio:averageLifespan": 15
+      },
+      {
+        "id": "bio:organisms/tiger",
+        "type": ["bio:Organism", "bio:classes/Feline"],
+        "schema:name": "Tiger",
+        "bio:scientificName": "Panthera tigris",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Endangered",
+        "bio:averageLifespan": 15
+      },
+      {
+        "id": "bio:organisms/domestic-cat",
+        "type": ["bio:Organism", "bio:classes/Feline"],
+        "schema:name": "Domestic Cat",
+        "bio:scientificName": "Felis catus",
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 15
+      },
+      {
+        "id": "bio:organisms/wolf",
+        "type": ["bio:Organism", "bio:classes/Canine"],
+        "schema:name": "Gray Wolf",
+        "bio:scientificName": "Canis lupus",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 13
+      },
+      {
+        "id": "bio:organisms/arctic-fox",
+        "type": ["bio:Organism", "bio:classes/Canine"],
+        "schema:name": "Arctic Fox",
+        "bio:scientificName": "Vulpes lagopus",
+        "bio:habitat": { "id": "bio:habitats/Arctic" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 5
+      },
+      {
+        "id": "bio:organisms/elephant",
+        "type": ["bio:Organism", "bio:classes/Herbivore"],
+        "schema:name": "African Elephant",
+        "bio:scientificName": "Loxodonta africana",
+        "bio:habitat": { "id": "bio:habitats/Grassland" },
+        "bio:conservationStatus": "Vulnerable",
+        "bio:averageLifespan": 60
+      },
+      {
+        "id": "bio:organisms/deer",
+        "type": ["bio:Organism", "bio:classes/Herbivore"],
+        "schema:name": "White-tailed Deer",
+        "bio:scientificName": "Odocoileus virginianus",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 6
+      },
+      {
+        "id": "bio:organisms/chimpanzee",
+        "type": ["bio:Organism", "bio:classes/Primate"],
+        "schema:name": "Chimpanzee",
+        "bio:scientificName": "Pan troglodytes",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Endangered",
+        "bio:averageLifespan": 40
+      },
+      {
+        "id": "bio:organisms/gorilla",
+        "type": ["bio:Organism", "bio:classes/Primate"],
+        "schema:name": "Mountain Gorilla",
+        "bio:scientificName": "Gorilla beringei beringei",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Endangered",
+        "bio:averageLifespan": 35
+      },
+      {
+        "id": "bio:organisms/mouse",
+        "type": ["bio:Organism", "bio:classes/Rodent"],
+        "schema:name": "House Mouse",
+        "bio:scientificName": "Mus musculus",
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 2
+      },
+      {
+        "id": "bio:organisms/beaver",
+        "type": ["bio:Organism", "bio:classes/Rodent"],
+        "schema:name": "North American Beaver",
+        "bio:scientificName": "Castor canadensis",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 15
+      },
+      {
+        "id": "bio:organisms/eagle",
+        "type": ["bio:Organism", "bio:classes/Raptor"],
+        "schema:name": "Bald Eagle",
+        "bio:scientificName": "Haliaeetus leucocephalus",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 20
+      },
+      {
+        "id": "bio:organisms/hawk",
+        "type": ["bio:Organism", "bio:classes/Raptor"],
+        "schema:name": "Red-tailed Hawk",
+        "bio:scientificName": "Buteo jamaicensis",
+        "bio:habitat": { "id": "bio:habitats/Grassland" },
+        "bio:conservationStatus": "Least Concern",
+        "bio:averageLifespan": 15
+      },
+      {
+        "id": "bio:organisms/cobra",
+        "type": ["bio:Organism", "bio:classes/Reptile"],
+        "schema:name": "King Cobra",
+        "bio:scientificName": "Ophiophagus hannah",
+        "bio:habitat": { "id": "bio:habitats/Forest" },
+        "bio:conservationStatus": "Vulnerable",
+        "bio:averageLifespan": 20
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/reasoning-seed-data/03_rules.json
+++ b/docs/examples/datasets/reasoning-seed-data/03_rules.json
@@ -1,0 +1,76 @@
+[
+  {
+    "@id": "biology-taxonomy",
+    "@graph": [
+      {
+        "id": "bio:properties/eats",
+        "type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:label": "eats",
+        "rdfs:comment": "Indicates that one organism eats another"
+      },
+      {
+        "id": "bio:properties/eatenBy",
+        "type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:label": "eaten by",
+        "rdfs:comment": "Inverse of eats - indicates this organism is eaten by another",
+        "owl:inverseOf": { "id": "bio:properties/eats" }
+      },
+      {
+        "id": "bio:properties/relatedTo",
+        "type": ["rdf:Property", "owl:ObjectProperty", "owl:SymmetricProperty"],
+        "rdfs:label": "related to",
+        "rdfs:comment": "Symmetric relationship indicating biological similarity"
+      },
+      {
+        "id": "bio:properties/ancestorOf",
+        "type": ["rdf:Property", "owl:ObjectProperty", "owl:TransitiveProperty"],
+        "rdfs:label": "ancestor of",
+        "rdfs:comment": "Transitive evolutionary ancestry"
+      },
+      {
+        "id": "bio:relationships/lion-eats-deer",
+        "type": "bio:PredatorPrey",
+        "bio:predator": { "id": "bio:organisms/lion" },
+        "bio:prey": { "id": "bio:organisms/deer" }
+      },
+      {
+        "id": "bio:relationships/wolf-eats-deer",
+        "type": "bio:PredatorPrey",
+        "bio:predator": { "id": "bio:organisms/wolf" },
+        "bio:prey": { "id": "bio:organisms/deer" }
+      },
+      {
+        "id": "bio:relationships/eagle-eats-mouse",
+        "type": "bio:PredatorPrey",
+        "bio:predator": { "id": "bio:organisms/eagle" },
+        "bio:prey": { "id": "bio:organisms/mouse" }
+      },
+      {
+        "id": "bio:relationships/hawk-eats-mouse",
+        "type": "bio:PredatorPrey",
+        "bio:predator": { "id": "bio:organisms/hawk" },
+        "bio:prey": { "id": "bio:organisms/mouse" }
+      },
+      {
+        "id": "bio:relationships/cobra-eats-mouse",
+        "type": "bio:PredatorPrey",
+        "bio:predator": { "id": "bio:organisms/cobra" },
+        "bio:prey": { "id": "bio:organisms/mouse" }
+      },
+      {
+        "id": "bio:relationships/lion-tiger-related",
+        "type": "bio:BiologicalRelationship",
+        "bio:organism1": { "id": "bio:organisms/lion" },
+        "bio:organism2": { "id": "bio:organisms/tiger" },
+        "bio:relationshipType": "same genus"
+      },
+      {
+        "id": "bio:relationships/chimp-gorilla-related",
+        "type": "bio:BiologicalRelationship",
+        "bio:organism1": { "id": "bio:organisms/chimpanzee" },
+        "bio:organism2": { "id": "bio:organisms/gorilla" },
+        "bio:relationshipType": "same family"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/reasoning-seed-data/defaultContext.json
+++ b/docs/examples/datasets/reasoning-seed-data/defaultContext.json
@@ -1,0 +1,11 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "owl": "http://www.w3.org/2002/07/owl#",
+  "schema": "http://schema.org/",
+  "bio": "https://biology-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/reasoning/introduction.mdx
+++ b/docs/examples/datasets/reasoning/introduction.mdx
@@ -1,0 +1,118 @@
+---
+title: Introduction
+---
+
+import { FlureeMermaid } from "@site/src/components/Mermaid/FlureeMermaid.jsx";
+import Admonition from "@theme/Admonition";
+
+# Reasoning & Inference
+
+This example demonstrates Fluree's reasoning capabilities using a biological taxonomy. You'll learn how to define rules that automatically infer new facts from your data—a powerful feature for knowledge graphs and ontology-driven applications.
+
+## The Scenario
+
+A wildlife research database needs to:
+
+- Classify organisms using a taxonomic hierarchy (Kingdom → Class → Order → Family)
+- Infer that a Tiger is a Mammal (even if only typed as Feline)
+- Define symmetric relationships (if A is related to B, then B is related to A)
+- Define inverse relationships (if A eats B, then B is eaten by A)
+- Query inferred facts alongside asserted facts
+
+## Schema Overview
+
+<FlureeMermaid
+  chart={`
+  graph TB
+    Animal --> Mammal
+    Animal --> Bird
+    Animal --> Reptile
+    Mammal --> Carnivore
+    Mammal --> Herbivore
+    Mammal --> Primate
+    Mammal --> Rodent
+    Carnivore --> Feline
+    Carnivore --> Canine
+    Bird --> Raptor
+  `}
+/>
+
+### Taxonomic Hierarchy
+
+Each class in the hierarchy is defined using `rdfs:subClassOf`:
+
+```json
+{
+  "id": "bio:classes/Feline",
+  "type": ["rdfs:Class", "bio:TaxonomicClass"],
+  "rdfs:label": "Feline",
+  "rdfs:subClassOf": { "id": "bio:classes/Carnivore" }
+}
+```
+
+When reasoning is enabled, a Tiger (typed as Feline) is automatically inferred to be:
+- A Carnivore
+- A Mammal
+- An Animal
+
+## OWL Property Types
+
+Fluree supports several OWL property types for automatic inference:
+
+| Property Type | Behavior |
+|--------------|----------|
+| `owl:TransitiveProperty` | If A→B and B→C, then A→C |
+| `owl:SymmetricProperty` | If A→B, then B→A |
+| `owl:InverseProperty` | If A→B via prop1, then B→A via prop2 |
+
+### Example: Inverse Properties
+
+```json
+{
+  "id": "bio:properties/eats",
+  "type": ["rdf:Property", "owl:ObjectProperty"],
+  "rdfs:label": "eats"
+},
+{
+  "id": "bio:properties/eatenBy",
+  "type": ["rdf:Property", "owl:ObjectProperty"],
+  "owl:inverseOf": { "id": "bio:properties/eats" }
+}
+```
+
+When you assert "Lion eats Deer", the system automatically infers "Deer eatenBy Lion".
+
+### Example: Symmetric Properties
+
+```json
+{
+  "id": "bio:properties/relatedTo",
+  "type": ["rdf:Property", "owl:ObjectProperty", "owl:SymmetricProperty"]
+}
+```
+
+If you assert "Lion relatedTo Tiger", the inverse "Tiger relatedTo Lion" is automatically inferred.
+
+## Organisms in the Dataset
+
+| Organism | Class | Habitat | Conservation |
+|----------|-------|---------|--------------|
+| Lion | Feline | Grassland | Vulnerable |
+| Tiger | Feline | Forest | Endangered |
+| Wolf | Canine | Forest | Least Concern |
+| Arctic Fox | Canine | Arctic | Least Concern |
+| Elephant | Herbivore | Grassland | Vulnerable |
+| Chimpanzee | Primate | Forest | Endangered |
+| Bald Eagle | Raptor | Forest | Least Concern |
+| King Cobra | Reptile | Forest | Vulnerable |
+
+## What You'll Learn
+
+In the following pages, you'll explore:
+
+1. **[Defining Rules](../rules/)** - Create OWL properties and class hierarchies
+2. **[Querying Inferred Data](../querying-inferred/)** - Query both asserted and inferred facts
+
+<Admonition type="info">
+  Reasoning enables you to store minimal facts and let the system derive additional knowledge, reducing data duplication and ensuring consistency.
+</Admonition>

--- a/docs/examples/datasets/reasoning/querying-inferred.mdx
+++ b/docs/examples/datasets/reasoning/querying-inferred.mdx
@@ -1,0 +1,270 @@
+---
+title: Querying Inferred Data
+---
+
+import Admonition from "@theme/Admonition";
+
+# Querying Inferred Data
+
+This page demonstrates how to query both asserted facts and inferred facts using Fluree's reasoning capabilities.
+
+## Find All Mammals
+
+With the class hierarchy in place, query for all Mammals:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?organism": ["schema:name", "bio:scientificName"]
+  },
+  "where": { "@id": "?organism", "@type": "bio:classes/Mammal" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+**Result includes:**
+- Lion (typed as Feline → inferred as Mammal)
+- Tiger (typed as Feline → inferred as Mammal)
+- Wolf (typed as Canine → inferred as Mammal)
+- Elephant (typed as Herbivore → inferred as Mammal)
+- Chimpanzee (typed as Primate → inferred as Mammal)
+- ... and all other mammals
+
+Without reasoning, only organisms explicitly typed as `bio:classes/Mammal` would be returned.
+
+## Find All Animals
+
+Go further up the hierarchy:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?organism": ["schema:name", "type"]
+  },
+  "where": { "@id": "?organism", "@type": "bio:classes/Animal" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+This returns ALL organisms in the database, since every class is a subclass of Animal.
+
+## Find All Carnivores
+
+Query for meat-eaters:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?organism": ["schema:name", "bio:habitat"]
+  },
+  "where": { "@id": "?organism", "@type": "bio:classes/Carnivore" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+**Result:**
+- Lion (Feline → Carnivore)
+- Tiger (Feline → Carnivore)
+- Domestic Cat (Feline → Carnivore)
+- Wolf (Canine → Carnivore)
+- Arctic Fox (Canine → Carnivore)
+
+## Query Inverse Relationships
+
+Find what each organism is eaten by:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?preyName", "?predatorName"],
+  "where": [
+    { "@id": "?prey", "bio:properties/eatenBy": "?predator", "schema:name": "?preyName" },
+    { "@id": "?predator", "schema:name": "?predatorName" }
+  ],
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+Even though we only asserted `eats` relationships, the inverse `eatenBy` is inferred:
+
+| Prey | Eaten By |
+|------|----------|
+| Deer | Lion |
+| Deer | Wolf |
+| Mouse | Eagle |
+| Mouse | Hawk |
+| Mouse | Cobra |
+
+## Find All Predators of an Organism
+
+What eats the mouse?
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?predator": ["schema:name", "type"]
+  },
+  "where": { "@id": "bio:organisms/mouse", "bio:properties/eatenBy": "?predator" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+**Result:** Bald Eagle, Red-tailed Hawk, King Cobra
+
+## Query Symmetric Relationships
+
+Find organisms related to the Lion:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?related": ["schema:name"]
+  },
+  "where": { "@id": "bio:organisms/lion", "bio:properties/relatedTo": "?related" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+Or query from the Tiger's perspective:
+
+```json
+{
+  "select": {
+    "?related": ["schema:name"]
+  },
+  "where": { "@id": "bio:organisms/tiger", "bio:properties/relatedTo": "?related" }
+}
+```
+
+Both queries return the same result due to symmetry.
+
+## Endangered Species Analysis
+
+Find endangered mammals:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?organism": ["schema:name", "bio:conservationStatus", "bio:habitat"]
+  },
+  "where": { "@id": "?organism", "@type": "bio:classes/Mammal", "bio:conservationStatus": "Endangered" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+**Result:**
+- Tiger (Feline → Mammal, Endangered)
+- Chimpanzee (Primate → Mammal, Endangered)
+- Gorilla (Primate → Mammal, Endangered)
+
+## Compare Inferred vs Asserted Types
+
+See all types (both asserted and inferred) for an organism:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": ["?type"],
+  "where": { "@id": "bio:organisms/tiger", "@type": "?type" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+**Result:**
+- `bio:Organism` (asserted)
+- `bio:classes/Feline` (asserted)
+- `bio:classes/Carnivore` (inferred)
+- `bio:classes/Mammal` (inferred)
+- `bio:classes/Animal` (inferred)
+
+## Habitat Analysis with Inference
+
+Find all animals in a specific habitat:
+
+```json
+{
+  "@context": {
+    "bio": "https://biology-example.com/ns/",
+    "schema": "http://schema.org/"
+  },
+  "select": {
+    "?organism": ["schema:name", "type"]
+  },
+  "where": { "@id": "?organism", "@type": "bio:classes/Animal", "bio:habitat": {"@id": "bio:habitats/Forest"} },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+Returns all forest-dwelling animals across the entire taxonomy.
+
+<Admonition type="tip">
+  Reasoning enables you to write simpler queries—ask for "Mammals" and get all organisms that are mammals, regardless of how specifically they were typed.
+</Admonition>
+
+## Performance Considerations
+
+Reasoning adds computational overhead. Strategies for optimization:
+
+1. **Materialize inferences**: Pre-compute and store inferred facts
+2. **Limit scope**: Use `reasoner` only when needed
+3. **Optimize hierarchy depth**: Deeper hierarchies = more inference work
+
+## Summary
+
+| Query Pattern | Result |
+|--------------|--------|
+| `type Animal` | All organisms (everything is an animal) |
+| `type Mammal` | All mammals including Felines, Canines, etc. |
+| `eatenBy ?predator` | Inverse of asserted `eats` relationships |
+| `relatedTo ?x` | Both directions of symmetric relationships |
+| All types for entity | Shows asserted + all inferred supertypes |
+
+Reasoning transforms your data model from explicit to expressive—store minimal facts, query rich knowledge.

--- a/docs/examples/datasets/reasoning/rules.mdx
+++ b/docs/examples/datasets/reasoning/rules.mdx
@@ -1,0 +1,225 @@
+---
+title: Defining Rules
+---
+
+import Admonition from "@theme/Admonition";
+
+# Defining Reasoning Rules
+
+This page demonstrates how to define class hierarchies and OWL properties that enable automatic inference in Fluree.
+
+## Class Hierarchies with rdfs:subClassOf
+
+The taxonomic hierarchy is built using `rdfs:subClassOf`:
+
+```json
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "bio": "https://biology-example.com/ns/"
+  },
+  "insert": [
+    {
+      "id": "bio:classes/Animal",
+      "type": "rdfs:Class",
+      "rdfs:label": "Animal"
+    },
+    {
+      "id": "bio:classes/Mammal",
+      "type": "rdfs:Class",
+      "rdfs:label": "Mammal",
+      "rdfs:subClassOf": { "id": "bio:classes/Animal" }
+    },
+    {
+      "id": "bio:classes/Carnivore",
+      "type": "rdfs:Class",
+      "rdfs:label": "Carnivore",
+      "rdfs:subClassOf": { "id": "bio:classes/Mammal" }
+    },
+    {
+      "id": "bio:classes/Feline",
+      "type": "rdfs:Class",
+      "rdfs:label": "Feline",
+      "rdfs:subClassOf": { "id": "bio:classes/Carnivore" }
+    }
+  ]
+}
+```
+
+This creates the chain: Feline → Carnivore → Mammal → Animal
+
+## Adding an Organism
+
+When you add a Tiger typed as Feline:
+
+```json
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "bio": "https://biology-example.com/ns/"
+  },
+  "insert": {
+    "id": "bio:organisms/tiger",
+    "type": ["bio:Organism", "bio:classes/Feline"],
+    "schema:name": "Tiger",
+    "bio:scientificName": "Panthera tigris"
+  }
+}
+```
+
+With reasoning enabled, the Tiger is automatically inferred to be:
+- A Feline (asserted)
+- A Carnivore (inferred)
+- A Mammal (inferred)
+- An Animal (inferred)
+
+## Inverse Properties
+
+Define two properties as inverses of each other:
+
+```json
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "bio": "https://biology-example.com/ns/"
+  },
+  "insert": [
+    {
+      "id": "bio:properties/eats",
+      "type": ["rdf:Property", "owl:ObjectProperty"],
+      "rdfs:label": "eats",
+      "rdfs:comment": "Predator eats prey"
+    },
+    {
+      "id": "bio:properties/eatenBy",
+      "type": ["rdf:Property", "owl:ObjectProperty"],
+      "rdfs:label": "eaten by",
+      "owl:inverseOf": { "id": "bio:properties/eats" }
+    }
+  ]
+}
+```
+
+Now when you assert a predator-prey relationship:
+
+```json
+{
+  "insert": {
+    "id": "bio:organisms/lion",
+    "bio:properties/eats": { "id": "bio:organisms/deer" }
+  }
+}
+```
+
+The inverse is automatically inferred:
+- `bio:organisms/deer` `bio:properties/eatenBy` `bio:organisms/lion`
+
+## Symmetric Properties
+
+For bidirectional relationships, use `owl:SymmetricProperty`:
+
+```json
+{
+  "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "bio": "https://biology-example.com/ns/"
+  },
+  "insert": {
+    "id": "bio:properties/relatedTo",
+    "type": ["rdf:Property", "owl:ObjectProperty", "owl:SymmetricProperty"],
+    "rdfs:label": "related to",
+    "rdfs:comment": "Symmetric biological relationship"
+  }
+}
+```
+
+Assert one direction:
+
+```json
+{
+  "insert": {
+    "id": "bio:organisms/lion",
+    "bio:properties/relatedTo": { "id": "bio:organisms/tiger" }
+  }
+}
+```
+
+The reverse is automatically inferred:
+- `bio:organisms/tiger` `bio:properties/relatedTo` `bio:organisms/lion`
+
+## Transitive Properties
+
+For chains of relationships, use `owl:TransitiveProperty`:
+
+```json
+{
+  "insert": {
+    "id": "bio:properties/ancestorOf",
+    "type": ["rdf:Property", "owl:ObjectProperty", "owl:TransitiveProperty"],
+    "rdfs:label": "ancestor of"
+  }
+}
+```
+
+If you assert:
+- A ancestorOf B
+- B ancestorOf C
+
+Then A ancestorOf C is automatically inferred.
+
+## Custom Rules
+
+For more complex inference, Fluree supports custom rules:
+
+```json
+{
+  "@context": {
+    "f": "https://ns.flur.ee/ledger#",
+    "bio": "https://biology-example.com/ns/"
+  },
+  "@id": "bio:rules/endangered-in-habitat",
+  "f:rule": {
+    "@type": "@json",
+    "@value": {
+      "@context": { "bio": "https://biology-example.com/ns/" },
+      "where": [
+        { "@id": "?organism", "bio:habitat": "?habitat" },
+        { "@id": "?organism", "bio:conservationStatus": "Endangered" }
+      ],
+      "insert": { "@id": "?habitat", "bio:hasEndangeredSpecies": { "@id": "?organism" } }
+    }
+  }
+}
+```
+
+This rule infers that a habitat has endangered species when any organism in that habitat has "Endangered" conservation status.
+
+## Enabling Reasoning
+
+Reasoning can be enabled at query time:
+
+```json
+{
+  "select": { "?organism": ["*"] },
+  "where": { "@id": "?organism", "@type": "bio:classes/Mammal" },
+  "opts": {
+    "reasoner": "owl2rl"
+  }
+}
+```
+
+Or configured at the ledger level for automatic reasoning on all queries.
+
+## Summary
+
+| Technique | Use Case |
+|-----------|----------|
+| `rdfs:subClassOf` | Class hierarchies (is-a relationships) |
+| `owl:inverseOf` | Bidirectional properties (eats ↔ eatenBy) |
+| `owl:SymmetricProperty` | Same property both directions |
+| `owl:TransitiveProperty` | Chained relationships (A→B→C implies A→C) |
+| Custom rules (`f:rule`) | Complex custom inference |
+
+Next, learn how to [query inferred data](../querying-inferred/) alongside asserted facts.

--- a/docs/examples/datasets/rest-api/advanced-patterns.mdx
+++ b/docs/examples/datasets/rest-api/advanced-patterns.mdx
@@ -1,0 +1,82 @@
+---
+title: Advanced Patterns
+---
+
+# Advanced API Patterns
+
+## Batch Transactions
+
+Insert multiple entities at once:
+
+```sh
+curl -X POST http://localhost:58090/fluree/transact \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "insert": [
+      { "id": "ex:users/1", "type": "ex:User", "schema:name": "Alice" },
+      { "id": "ex:users/2", "type": "ex:User", "schema:name": "Bob" },
+      { "id": "ex:users/3", "type": "ex:User", "schema:name": "Carol" }
+    ]
+  }'
+```
+
+## Error Handling
+
+Check the response status:
+- `200`: Success
+- `400`: Invalid request (check query syntax)
+- `500`: Server error
+
+Response includes details:
+```json
+{
+  "error": "Invalid query syntax",
+  "message": "..."
+}
+```
+
+## Pagination
+
+Use `limit` and `offset`:
+
+```sh
+curl -X POST http://localhost:58090/fluree/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "select": { "?user": ["*"] },
+    "where": { "@id": "?user", "@type": "ex:User" },
+    "limit": 10,
+    "offset": 20
+  }'
+```
+
+## History Query
+
+```sh
+curl -X POST http://localhost:58090/fluree/history \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "history": { "@id": "ex:users/1" }
+  }'
+```
+
+## Query with Context
+
+Include context in the request:
+
+```sh
+curl -X POST http://localhost:58090/fluree/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "@context": {
+      "ex": "https://example.com/ns/",
+      "schema": "http://schema.org/"
+    },
+    "select": { "?user": ["schema:name"] },
+    "where": { "@id": "?user", "@type": "ex:User" }
+  }'
+```

--- a/docs/examples/datasets/rest-api/crud-operations.mdx
+++ b/docs/examples/datasets/rest-api/crud-operations.mdx
@@ -1,0 +1,62 @@
+---
+title: CRUD Operations
+---
+
+# CRUD Operations
+
+## Create (Insert)
+
+```sh
+curl -X POST http://localhost:58090/fluree/transact \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "insert": {
+      "id": "ex:users/1",
+      "type": "ex:User",
+      "schema:name": "Alice",
+      "schema:email": "alice@example.com"
+    }
+  }'
+```
+
+## Read (Query)
+
+```sh
+curl -X POST http://localhost:58090/fluree/query \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "select": { "?user": ["*"] },
+    "where": { "@id": "?user", "@type": "ex:User" }
+  }'
+```
+
+## Update
+
+```sh
+curl -X POST http://localhost:58090/fluree/transact \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "delete": { "id": "ex:users/1", "schema:email": "alice@example.com" },
+    "insert": { "id": "ex:users/1", "schema:email": "alice.new@example.com" }
+  }'
+```
+
+## Delete
+
+```sh
+curl -X POST http://localhost:58090/fluree/transact \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ledger": "my/ledger",
+    "delete": {
+      "id": "ex:users/1",
+      "schema:name": null,
+      "schema:email": null
+    }
+  }'
+```
+
+Using `null` deletes all values for that property.

--- a/docs/examples/datasets/rest-api/introduction.mdx
+++ b/docs/examples/datasets/rest-api/introduction.mdx
@@ -1,0 +1,32 @@
+---
+title: Introduction
+---
+
+# REST API Patterns
+
+This guide demonstrates common HTTP API operations with Fluree, showing curl examples for all CRUD operations.
+
+## Base URL
+
+All examples assume Fluree is running at:
+```
+http://localhost:58090/fluree
+```
+
+## Available Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/create` | POST | Create a new ledger |
+| `/transact` | POST | Insert/update/delete data |
+| `/query` | POST | Query data |
+| `/history` | POST | Query historical data |
+
+## Authentication
+
+For secured deployments, include an authorization header:
+```sh
+-H "Authorization: Bearer YOUR_TOKEN"
+```
+
+See the detailed examples in the following pages.

--- a/docs/examples/datasets/shacl-validation-seed-data/01_shapes.json
+++ b/docs/examples/datasets/shacl-validation-seed-data/01_shapes.json
@@ -1,0 +1,52 @@
+[
+  {
+    "@id": "validation-shapes",
+    "@graph": [
+      {
+        "id": "ex:PersonShape",
+        "type": "sh:NodeShape",
+        "sh:targetClass": { "id": "ex:Person" },
+        "sh:property": [
+          {
+            "sh:path": { "id": "schema:givenName" },
+            "sh:minCount": 1,
+            "sh:maxCount": 1,
+            "sh:datatype": { "id": "xsd:string" },
+            "sh:message": "Person must have exactly one given name"
+          },
+          {
+            "sh:path": { "id": "schema:email" },
+            "sh:minCount": 1,
+            "sh:pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+            "sh:message": "Must have a valid email address"
+          },
+          {
+            "sh:path": { "id": "ex:age" },
+            "sh:minInclusive": 0,
+            "sh:maxInclusive": 150,
+            "sh:message": "Age must be between 0 and 150"
+          }
+        ]
+      },
+      {
+        "id": "ex:OrderShape",
+        "type": "sh:NodeShape",
+        "sh:targetClass": { "id": "ex:Order" },
+        "sh:property": [
+          {
+            "sh:path": { "id": "ex:customer" },
+            "sh:minCount": 1,
+            "sh:class": { "id": "ex:Person" },
+            "sh:message": "Order must have a customer"
+          },
+          {
+            "sh:path": { "id": "ex:totalAmount" },
+            "sh:minCount": 1,
+            "sh:minExclusive": 0,
+            "sh:message": "Total amount must be greater than 0"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/shacl-validation-seed-data/02_data.json
+++ b/docs/examples/datasets/shacl-validation-seed-data/02_data.json
@@ -1,0 +1,22 @@
+[
+  {
+    "@id": "validation-data",
+    "@graph": [
+      {
+        "id": "ex:people/valid-person",
+        "type": "ex:Person",
+        "schema:givenName": "Alice",
+        "schema:familyName": "Smith",
+        "schema:email": "alice@example.com",
+        "ex:age": 30
+      },
+      {
+        "id": "ex:orders/valid-order",
+        "type": "ex:Order",
+        "ex:customer": { "id": "ex:people/valid-person" },
+        "ex:totalAmount": 99.99,
+        "ex:orderDate": "2024-03-15"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/shacl-validation-seed-data/defaultContext.json
+++ b/docs/examples/datasets/shacl-validation-seed-data/defaultContext.json
@@ -1,0 +1,8 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "sh": "http://www.w3.org/ns/shacl#",
+  "schema": "http://schema.org/",
+  "ex": "https://example.com/ns/",
+  "xsd": "http://www.w3.org/2001/XMLSchema#"
+}

--- a/docs/examples/datasets/shacl-validation/defining-shapes.mdx
+++ b/docs/examples/datasets/shacl-validation/defining-shapes.mdx
@@ -1,0 +1,73 @@
+---
+title: Defining Shapes
+---
+
+# Defining SHACL Shapes
+
+## Required Properties
+
+Require that a Person has a name:
+
+```json
+{
+  "sh:property": {
+    "sh:path": { "id": "schema:givenName" },
+    "sh:minCount": 1,
+    "sh:message": "Person must have a given name"
+  }
+}
+```
+
+## Cardinality Constraints
+
+Exactly one email:
+
+```json
+{
+  "sh:property": {
+    "sh:path": { "id": "schema:email" },
+    "sh:minCount": 1,
+    "sh:maxCount": 1
+  }
+}
+```
+
+## Value Ranges
+
+Age between 0 and 150:
+
+```json
+{
+  "sh:property": {
+    "sh:path": { "id": "ex:age" },
+    "sh:minInclusive": 0,
+    "sh:maxInclusive": 150
+  }
+}
+```
+
+## Pattern Matching
+
+Email format validation:
+
+```json
+{
+  "sh:property": {
+    "sh:path": { "id": "schema:email" },
+    "sh:pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+  }
+}
+```
+
+## Type Constraints
+
+Customer must be a Person:
+
+```json
+{
+  "sh:property": {
+    "sh:path": { "id": "ex:customer" },
+    "sh:class": { "id": "ex:Person" }
+  }
+}
+```

--- a/docs/examples/datasets/shacl-validation/introduction.mdx
+++ b/docs/examples/datasets/shacl-validation/introduction.mdx
@@ -1,0 +1,40 @@
+---
+title: Introduction
+---
+
+import Admonition from "@theme/Admonition";
+
+# SHACL Validation
+
+This example demonstrates data validation using SHACL (Shapes Constraint Language). Define shapes that describe valid data, and Fluree will reject transactions that violate those constraints.
+
+## What is SHACL?
+
+SHACL is a W3C standard for describing data shapes. It allows you to:
+
+- **Require properties**: A Person must have an email
+- **Constrain values**: Age must be between 0 and 150
+- **Validate patterns**: Email must match a regex
+- **Enforce cardinality**: Exactly one given name
+- **Check types**: Customer must be a Person
+
+## Example Shape
+
+```json
+{
+  "id": "ex:PersonShape",
+  "type": "sh:NodeShape",
+  "sh:targetClass": { "id": "ex:Person" },
+  "sh:property": [
+    {
+      "sh:path": { "id": "schema:email" },
+      "sh:minCount": 1,
+      "sh:pattern": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+    }
+  ]
+}
+```
+
+<Admonition type="info">
+  SHACL validation happens at transaction time—invalid data is rejected before it enters the ledger.
+</Admonition>

--- a/docs/examples/datasets/shacl-validation/validation-errors.mdx
+++ b/docs/examples/datasets/shacl-validation/validation-errors.mdx
@@ -1,0 +1,76 @@
+---
+title: Validation Errors
+---
+
+# Handling Validation Errors
+
+## Invalid Data Examples
+
+### Missing Required Field
+
+This transaction will fail—no email:
+
+```json
+{
+  "insert": {
+    "id": "ex:people/invalid",
+    "type": "ex:Person",
+    "schema:givenName": "Bob"
+  }
+}
+```
+
+**Error:** "Must have a valid email address"
+
+### Invalid Value Range
+
+This transaction will fail—age too high:
+
+```json
+{
+  "insert": {
+    "id": "ex:people/invalid-age",
+    "type": "ex:Person",
+    "schema:givenName": "Ancient",
+    "schema:email": "ancient@example.com",
+    "ex:age": 200
+  }
+}
+```
+
+**Error:** "Age must be between 0 and 150"
+
+### Invalid Pattern
+
+This transaction will fail—bad email format:
+
+```json
+{
+  "insert": {
+    "id": "ex:people/bad-email",
+    "type": "ex:Person",
+    "schema:givenName": "Test",
+    "schema:email": "not-an-email"
+  }
+}
+```
+
+**Error:** "Must have a valid email address"
+
+## Valid Data Example
+
+This transaction succeeds:
+
+```json
+{
+  "insert": {
+    "id": "ex:people/valid",
+    "type": "ex:Person",
+    "schema:givenName": "Alice",
+    "schema:email": "alice@example.com",
+    "ex:age": 30
+  }
+}
+```
+
+SHACL validation ensures data quality at the database level.

--- a/docs/examples/datasets/sql-migration/introduction.mdx
+++ b/docs/examples/datasets/sql-migration/introduction.mdx
@@ -1,0 +1,34 @@
+---
+title: Introduction
+---
+
+# SQL Migration Guide
+
+This guide helps developers familiar with relational databases understand how to model and query data in Fluree's graph model.
+
+## Conceptual Mapping
+
+| SQL Concept | Fluree Equivalent |
+|-------------|-------------------|
+| Table | Class/Type |
+| Row | Entity (node) |
+| Column | Property |
+| Primary Key | Entity ID (`@id`) |
+| Foreign Key | Relationship (reference) |
+| JOIN | Graph traversal |
+| Schema | Ontology |
+
+## Key Differences
+
+1. **No fixed schema**: Properties can be added to any entity
+2. **Relationships are first-class**: No join tables needed
+3. **Multi-valued properties**: An entity can have multiple values for a property
+4. **Semantic types**: Properties carry meaning via ontologies
+
+## When to Migrate
+
+Consider Fluree when you need:
+- Complex relationships (many-to-many, hierarchies)
+- Flexible schemas that evolve
+- Built-in versioning and audit trails
+- Semantic data integration

--- a/docs/examples/datasets/sql-migration/query-comparison.mdx
+++ b/docs/examples/datasets/sql-migration/query-comparison.mdx
@@ -1,0 +1,81 @@
+---
+title: Query Comparison
+---
+
+# Query Comparison: SQL vs FlureeQL
+
+## Simple SELECT
+
+**SQL:**
+```sql
+SELECT name, email FROM users WHERE id = 1;
+```
+
+**FlureeQL:**
+```json
+{
+  "select": { "?user": ["schema:name", "schema:email"] },
+  "where": { "@id": "ex:users/1", "schema:name": "?name", "schema:email": "?email" }
+}
+```
+
+## JOIN
+
+**SQL:**
+```sql
+SELECT u.name, o.total
+FROM users u
+JOIN orders o ON u.id = o.user_id;
+```
+
+**FlureeQL:**
+```json
+{
+  "select": ["?userName", "?total"],
+  "where": [
+    { "@id": "?order", "ex:customer": "?user", "ex:total": "?total" },
+    { "@id": "?user", "schema:name": "?userName" }
+  ]
+}
+```
+
+No explicit JOIN—graph traversal is natural.
+
+## GROUP BY with COUNT
+
+**SQL:**
+```sql
+SELECT user_id, COUNT(*)
+FROM orders
+GROUP BY user_id;
+```
+
+**FlureeQL:**
+```json
+{
+  "select": ["?user", "(count ?order)"],
+  "where": { "@id": "?order", "ex:customer": "?user" },
+  "groupBy": "?user"
+}
+```
+
+## Subquery
+
+**SQL:**
+```sql
+SELECT * FROM users
+WHERE id IN (SELECT user_id FROM orders WHERE total > 100);
+```
+
+**FlureeQL:**
+```json
+{
+  "select": { "?user": ["*"] },
+  "where": [
+    { "@id": "?order", "ex:customer": "?user", "ex:total": "?total" },
+    ["filter", "(> ?total 100)"]
+  ]
+}
+```
+
+The graph model eliminates the need for subqueries.

--- a/docs/examples/datasets/sql-migration/schema-mapping.mdx
+++ b/docs/examples/datasets/sql-migration/schema-mapping.mdx
@@ -1,0 +1,78 @@
+---
+title: Schema Mapping
+---
+
+# Schema Mapping: SQL to Graph
+
+## SQL Table → Fluree Class
+
+**SQL:**
+```sql
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100),
+  email VARCHAR(100) UNIQUE
+);
+```
+
+**Fluree:**
+```json
+{
+  "insert": {
+    "id": "ex:users/1",
+    "type": "ex:User",
+    "schema:name": "Alice",
+    "schema:email": "alice@example.com"
+  }
+}
+```
+
+## Foreign Keys → Relationships
+
+**SQL:**
+```sql
+CREATE TABLE orders (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  total DECIMAL
+);
+```
+
+**Fluree:**
+```json
+{
+  "insert": {
+    "id": "ex:orders/1",
+    "type": "ex:Order",
+    "ex:customer": { "id": "ex:users/1" },
+    "ex:total": 99.99
+  }
+}
+```
+
+No foreign key constraints—relationships are direct references.
+
+## Join Table → Multi-valued Property
+
+**SQL (many-to-many):**
+```sql
+CREATE TABLE user_roles (
+  user_id INTEGER REFERENCES users(id),
+  role_id INTEGER REFERENCES roles(id)
+);
+```
+
+**Fluree:**
+```json
+{
+  "insert": {
+    "id": "ex:users/1",
+    "ex:roles": [
+      { "id": "ex:roles/admin" },
+      { "id": "ex:roles/editor" }
+    ]
+  }
+}
+```
+
+No join table needed—multi-valued properties handle many-to-many naturally.

--- a/docs/examples/datasets/time-travel-seed-data/01_data.json
+++ b/docs/examples/datasets/time-travel-seed-data/01_data.json
@@ -1,0 +1,39 @@
+[
+  {
+    "@id": "financial-data",
+    "@graph": [
+      {
+        "id": "fin:accounts/checking-001",
+        "type": "fin:Account",
+        "schema:name": "Main Checking",
+        "fin:accountNumber": "CHK-001",
+        "fin:balance": 5000.00,
+        "fin:accountType": "checking"
+      },
+      {
+        "id": "fin:accounts/savings-001",
+        "type": "fin:Account",
+        "schema:name": "Emergency Fund",
+        "fin:accountNumber": "SAV-001",
+        "fin:balance": 10000.00,
+        "fin:accountType": "savings"
+      },
+      {
+        "id": "fin:transactions/tx-001",
+        "type": "fin:Transaction",
+        "fin:account": { "id": "fin:accounts/checking-001" },
+        "fin:amount": -500.00,
+        "fin:description": "Rent payment",
+        "fin:date": "2024-03-01"
+      },
+      {
+        "id": "fin:transactions/tx-002",
+        "type": "fin:Transaction",
+        "fin:account": { "id": "fin:accounts/checking-001" },
+        "fin:amount": 3000.00,
+        "fin:description": "Salary deposit",
+        "fin:date": "2024-03-15"
+      }
+    ]
+  }
+]

--- a/docs/examples/datasets/time-travel-seed-data/defaultContext.json
+++ b/docs/examples/datasets/time-travel-seed-data/defaultContext.json
@@ -1,0 +1,7 @@
+{
+  "id": "@id",
+  "type": "@type",
+  "schema": "http://schema.org/",
+  "fin": "https://finance-example.com/ns/",
+  "f": "https://ns.flur.ee/ledger#"
+}

--- a/docs/examples/datasets/time-travel/history-queries.mdx
+++ b/docs/examples/datasets/time-travel/history-queries.mdx
@@ -1,0 +1,70 @@
+---
+title: History Queries
+---
+
+# Time-Travel Queries
+
+## Point-in-Time Query
+
+See account balance as of a specific date:
+
+```json
+{
+  "@context": { "fin": "https://finance-example.com/ns/", "schema": "http://schema.org/" },
+  "select": { "?account": ["schema:name", "fin:balance"] },
+  "where": { "@id": "?account", "@type": "fin:Account" },
+  "opts": {
+    "t": "2024-03-01"
+  }
+}
+```
+
+## Entity History
+
+Get all changes to an account:
+
+```json
+{
+  "@context": { "fin": "https://finance-example.com/ns/" },
+  "history": { "@id": "fin:accounts/checking-001" },
+  "opts": {
+    "showAssertions": true
+  }
+}
+```
+
+Returns every assertion and retraction with timestamps.
+
+## Balance Over Time
+
+Track balance changes:
+
+```json
+{
+  "@context": { "fin": "https://finance-example.com/ns/" },
+  "history": { "@id": "fin:accounts/checking-001" },
+  "select": ["fin:balance"],
+  "opts": {
+    "t": { "from": "2024-01-01", "to": "2024-03-31" }
+  }
+}
+```
+
+## Transaction Audit
+
+All transactions for an account:
+
+```json
+{
+  "@context": { "fin": "https://finance-example.com/ns/" },
+  "select": { "?tx": ["fin:amount", "fin:description", "fin:date"] },
+  "where": { "@id": "?tx", "fin:account": {"@id": "fin:accounts/checking-001"} },
+  "orderBy": [{"desc": "?date"}]
+}
+```
+
+## Compare Points in Time
+
+See what changed between two dates by running the same query with different `t` values and comparing results.
+
+The immutable ledger ensures complete auditability for compliance requirements.

--- a/docs/examples/datasets/time-travel/introduction.mdx
+++ b/docs/examples/datasets/time-travel/introduction.mdx
@@ -1,0 +1,31 @@
+---
+title: Introduction
+---
+
+import Admonition from "@theme/Admonition";
+
+# Time-Travel & Audit
+
+This example demonstrates Fluree's immutable ledger and time-travel query capabilities using a financial audit scenario.
+
+## Immutability
+
+Every transaction in Fluree is immutable—data is never deleted, only new facts are added. This creates a complete audit trail perfect for:
+
+- Financial compliance
+- Regulatory audits
+- Debugging and forensics
+- Historical analysis
+
+## Key Capabilities
+
+| Feature | Description |
+|---------|-------------|
+| **Point-in-time queries** | See data as it was at any timestamp |
+| **History queries** | Get all changes to an entity |
+| **Audit trail** | Who changed what, when |
+| **Data recovery** | Revert to previous states |
+
+<Admonition type="info">
+  Fluree's immutability is built into the core architecture—every query can optionally include a time parameter to view historical data.
+</Admonition>


### PR DESCRIPTION
## Summary

Adds 7 feature-focused example datasets to **Examples > Feature Showcases**:

### Policy & Access Control
- Users, organizations, documents with policies
- Demonstrates f:Policy rules and testing

### Reasoning & Inference
- Biological taxonomy with OWL rules
- Demonstrates transitive/symmetric properties

### Full-Text Search
- Recipe database with search
- Demonstrates Lucene integration

### SHACL Validation
- Shapes and validation examples
- Demonstrates constraint violations

### Time-Travel & Audit
- Data with historical queries
- Demonstrates as-of and history queries

### SQL Migration
- Side-by-side SQL/FlureeQL comparison
- Helps SQL users transition

### REST API Patterns
- CRUD operations via HTTP
- Demonstrates API integration

Each includes seed data JSON files and tutorial guides.

## Test plan

- [ ] Load seed data into test instance
- [ ] Verify feature examples demonstrate advertised capabilities