### PR TITLE
docs: fix cloud doc typos

### DIFF
--- a/docs/cloud/datasets/data-management/change.mdx
+++ b/docs/cloud/datasets/data-management/change.mdx
@@ -57,4 +57,4 @@ In the editor mode, make sure that it is set to "Transact" mode.
 
 From here, you can place any valid transactable data inside the `txn` object, and then click the "Transact" button to commit your data to the dataset.
 
-For more on how to transact your own JSON data in this fashion, [click here](/docs/reference/http-api#flureetransact).
+For more on how to transact your own JSON data in this fashion, [click here](/docs/reference/http-api/transactions#flureetransact).

--- a/docs/cloud/datasets/data-management/view.mdx
+++ b/docs/cloud/datasets/data-management/view.mdx
@@ -104,4 +104,4 @@ Currently, only queries using FlureeQL are supported, but SPARQL query support i
   />
 </FigureWithCaption>
 
-[Click here](/docs/reference/flureeql-query-syntax) to find out more about querying your Nexus datasets.
+[Click here](/docs/reference/querying/) to find out more about querying your Nexus datasets.

--- a/docs/cloud/datasets/notebooks.mdx
+++ b/docs/cloud/datasets/notebooks.mdx
@@ -112,7 +112,7 @@ Each Markdown cell contains a "done" button: <Check className="h-6 w-6 text-flur
 
 ### FlureeQL
 
-FlureeQL is a JSON-based query language for retrieving Fluree data. It is modeled as a JSON-representation of the W3C SPARQL standard. You can use FlureeQL cells to create ledgers, query, and transact data. For more information, check out our documentation on [FlureeQL Query Syntax](../../../reference/flureeql-query-syntax/).
+FlureeQL is a JSON-based query language for retrieving Fluree data. It is modeled as a JSON-representation of the W3C SPARQL standard. You can use FlureeQL cells to create ledgers, query, and transact data. For more information, check out our documentation on [FlureeQL Query Syntax](/docs/reference/querying/).
 
 One of the NIFTIEST things about FlureeQL cells is that, based on the contents of your syntax, the Notebook can anticipate if you are attempting to query a ledger, highlighting the "play" icon:
 

--- a/docs/cloud/datasets/overview.mdx
+++ b/docs/cloud/datasets/overview.mdx
@@ -31,7 +31,7 @@ We will step through each of the tabs in the `Dataset View`. They include:
 - **[`Policies`](../policies/)**: UI for managing the `access control policies` for your dataset.
 - **[`Settings`](../settings/)**: Settings for your dataset, including management for `collaborators` and `API keys` for application integration.
 - **[`Notebooks`](../notebooks/)**: UI for organizing and saving sets of `queries`, `transactions`, and notes, for your own use or to share with others.
-- **`Queries`**: UI for querying and transacting against your dataset. See our [Cookbook of Query Examples](/docs/reference/cookbook/#querying) for examples.
+- **`Queries`**: UI for querying and transacting against your dataset. See our [Cookbook of Query Examples](/docs/reference/cookbook/examples#querying) for examples.
 - **[`Chats`](../how-to/chat/intro.mdx)**: Ask questions and explore your data using a natural language interface grounded in your dataset's structure.
 
 ---

--- a/docs/cloud/datasets/settings.mdx
+++ b/docs/cloud/datasets/settings.mdx
@@ -50,7 +50,7 @@ The _Collaborators_ tab of the _Settings UI_ allows you to view and manage the i
 <Admonition type="info">
 By default, each dataset will start with a `ReadAllRole` that allows read-only access to data in your dataset.
 
-More nuanced roles can be created (e.g. that only have read-access to particular classes or even to particular properties on particular classes) via the Policy Management UI or directly through transactions that establish _Policies_ and _PolicyGroups_. You can see some [examples of those in our Cookbook, here](/docs/reference/cookbook/#limiting-access).
+More nuanced roles can be created (e.g. that only have read-access to particular classes or even to particular properties on particular classes) via the Policy Management UI or directly through transactions that establish _Policies_ and _PolicyGroups_. You can see some [examples of those in our Cookbook, here](/docs/reference/cookbook/examples#limiting-access).
 
 </Admonition>
 

--- a/docs/cloud/how-to/chat/with-structured.mdx
+++ b/docs/cloud/how-to/chat/with-structured.mdx
@@ -38,7 +38,7 @@ Choose the path that matches your source data and follow the guide with the goal
     You have a custom ontology or data model that you want to use. */}
 
 ### Path: Upload Tables
-Fluree's [native data format](../../../../learn/tutorial/fluree-data-model/#understanding-json-ld-flurees-data-model), JSON-LD, can easily represent structured data from a variety of sources and formats, including CSV.
+Fluree's [native data format](/docs/learn/foundations/how-fluree-stores-data/), JSON-LD, can easily represent structured data from a variety of sources and formats, including CSV.
 And there are many fantastic tools and libraries that can help you convert your structured data into JSON-LD.  
 That said, as mentioned in the [Introduction](./intro.mdx#fdatamodel), the Fluree Data Agent is designed to work with a specific data model, the `f:DataModel`.
 This guide, with the help of the provided `Import Template` and Fluree Cloud's `File Import` tool, will help you import your structured data with a compatible `f:DataModel` so that you can chat with your data.


### PR DESCRIPTION
## Summary

Minor typo fixes across 6 Fluree Cloud documentation files:

- docs/cloud/datasets/data-management/change.mdx
- docs/cloud/datasets/data-management/view.mdx
- docs/cloud/datasets/notebooks.mdx
- docs/cloud/datasets/overview.mdx
- docs/cloud/datasets/settings.mdx
- docs/cloud/how-to/chat/with-structured.mdx

## Test plan

- [ ] Review changes for accuracy